### PR TITLE
More honest internal method name

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -290,7 +290,8 @@ impl<'a> EntriesFields<'a> {
                     return Err(other("two long name entries describing \
                                       the same member"))
                 }
-                gnu_longname = Some(try!(EntryFields::from(entry).read_all()));
+                gnu_longname =
+                    Some(try!(EntryFields::from(entry).read_all_limited()));
                 continue
             }
 
@@ -300,7 +301,8 @@ impl<'a> EntriesFields<'a> {
                     return Err(other("two long name entries describing \
                                       the same member"))
                 }
-                gnu_longlink = Some(try!(EntryFields::from(entry).read_all()));
+                gnu_longlink =
+                    Some(try!(EntryFields::from(entry).read_all_limited()));
                 continue
             }
 
@@ -310,7 +312,8 @@ impl<'a> EntriesFields<'a> {
                     return Err(other("two pax extensions entries describing \
                                       the same member"))
                 }
-                pax_extensions = Some(try!(EntryFields::from(entry).read_all()));
+                pax_extensions =
+                    Some(try!(EntryFields::from(entry).read_all_limited()));
                 continue
             }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -164,7 +164,7 @@ impl<'a> EntryFields<'a> {
         }
     }
 
-    pub fn read_all(&mut self) -> io::Result<Vec<u8>> {
+    pub fn read_all_limited(&mut self) -> io::Result<Vec<u8>> {
         // Preallocate some data but don't let ourselves get too crazy now.
         let cap = cmp::min(self.size, 128 * 1024);
         let mut v = Vec::with_capacity(cap as usize);
@@ -202,7 +202,7 @@ impl<'a> EntryFields<'a> {
                !self.header.entry_type().is_pax_local_extensions() {
                 return Ok(None)
             }
-            self.pax_extensions = Some(try!(self.read_all()));
+            self.pax_extensions = Some(try!(self.read_all_limited()));
         }
         Ok(Some(pax_extensions(self.pax_extensions.as_ref().unwrap())))
     }


### PR DESCRIPTION
Sorry, I didn't get a chance to look through #50 fully so I missed this - if I was reading tar-rs I'd be pretty suprised at `read_all` not doing what it says on the tin!