### PR TITLE
Fix `entry.header().path()` to `entry.path()` in examples

### DIFF
--- a/examples/extract_file.rs
+++ b/examples/extract_file.rs
@@ -18,7 +18,7 @@ fn main() {
     let mut arch = Archive::new(stdin());
     for file in arch.entries().unwrap() {
         let mut f = file.unwrap();
-        if f.header().path().unwrap() == filename {
+        if f.path().unwrap() == filename {
             copy(&mut f, &mut stdout()).unwrap();
         }
     }

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -12,6 +12,6 @@ fn main() {
     let mut arch = Archive::new(stdin());
     for file in arch.entries().unwrap() {
         let f= file.unwrap();
-        println!("{}", f.header().path().unwrap().display());
+        println!("{}", f.path().unwrap().display());
     }
 }


### PR DESCRIPTION
This fixes issue #63 in examples