### PR TITLE
Don't fill atime and ctime (7-zip compat)

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -599,10 +599,6 @@ impl Header {
 
         self.set_mode((meta.mode() & 0o3777) as u32);
         self.set_mtime(meta.mtime() as u64);
-        if let Some(gnu) = self.as_gnu_mut() {
-            gnu.set_atime(meta.atime() as u64);
-            gnu.set_ctime(meta.ctime() as u64);
-        }
         self.set_uid(meta.uid() as u32);
         self.set_gid(meta.gid() as u32);
 


### PR DESCRIPTION
The atime and ctime fields in the GNU entry header seem to be
deprecated. GNU tar only fills them in when --incremental is passed and
the manpage calls that variation "old GNU-format".

Filling the two fields is problematic because 7-zip (which is rather
popular on Windows) interprets the timestamps as directories. WinRAR is
not affected, but libarchive ignores the two fields. Since they are not
well-supported, it's better to leave them empty.

Fixes: #70