### PR TITLE
Use the right name for @LongLink entries

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -243,7 +243,7 @@ fn append_fs(dst: &mut Write,
             return Err(e)
         }
         let mut header2 = Header::new_gnu();
-        try!(header2.set_path("././@LongLink"));
+        header2.as_gnu_mut().unwrap().name[..13].clone_from_slice(b"././@LongLink");
         header2.set_mode(0o644);
         header2.set_uid(0);
         header2.set_gid(0);


### PR DESCRIPTION
These seem to be found with a name of `././@LongLink`, however
`copy_path_into` emits that as `@LongLink`. This is more tricky to fix
because `Path::components()` collapses that into `./@LongLink`. For now,
just special-case them.

The implementation here is not ideal since it will change the behavior
for non-GNU entries.

Fixes #76