### PR TITLE
Table name should be quoted with quotation marks not single quotes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ filetime = "0.1.5"
 [dev-dependencies]
 tempdir = "0.3"
 
-[target.'cfg(unix)'.dependencies]
+[target."cfg(unix)".dependencies]
 xattr = "0.1.7"


### PR DESCRIPTION
I ran into an issue running cargo-bootstrap; turns out pytoml doesn't like the Cargo.toml for this library and I think (but I'm not certain) that it isn't valid TOML.

Here's [the line causing issues](https://github.com/alexcrichton/tar-rs/blob/50239833e0dc173859e1f0876d53817e2185d0c8/Cargo.toml#L27):

    [target.'cfg(unix)'.dependencies]

Changing the single quotes to quotation marks makes pytoml happy again. My take of the TOML spec is that this is correct:

>  Keys may be either bare or quoted. Bare keys may only contain letters, numbers, underscores, and dashes (A-Za-z0-9_-). Quoted keys follow the exact same rules as basic strings

– [Tables, TOML spec](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md#table)

> There are four ways to express strings: basic, multi-line basic, literal, and multi-line literal [...] Basic strings are surrounded by quotation marks [...] Literal strings are surrounded by single quotes

[Strings, TOML spec](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md#string)

Thoughts?