### PR TITLE
Query raw byte positions of the header and file of an entry

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -183,6 +183,7 @@ impl<'a> EntriesFields<'a> {
         let delta = self.next - self.archive.inner.pos.get();
         try!(self.archive.skip(delta));
 
+        let header_pos = self.next;
         let mut header = Header::new_old();
         try!(read_all(&mut &self.archive.inner, header.as_mut_bytes()));
         self.next += 512;
@@ -212,10 +213,13 @@ impl<'a> EntriesFields<'a> {
             return Err(other("archive header checksum mismatch"))
         }
 
+        let file_pos = self.next;
         let size = try!(header.entry_size());
 
         let ret = EntryFields {
             size: size,
+            header_pos: header_pos,
+            file_pos: file_pos,
             data: vec![EntryIo::Data((&self.archive.inner).take(size))],
             header: header,
             long_pathname: None,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -33,6 +33,8 @@ pub struct EntryFields<'a> {
     pub pax_extensions: Option<Vec<u8>>,
     pub header: Header,
     pub size: u64,
+    pub header_pos: u64,
+    pub file_pos: u64,
     pub data: Vec<EntryIo<'a>>,
     pub unpack_xattrs: bool,
     pub preserve_permissions: bool,
@@ -123,6 +125,26 @@ impl<'a, R: Read> Entry<'a, R> {
     /// This provides access to the the metadata for this entry in the archive.
     pub fn header(&self) -> &Header {
         &self.fields.header
+    }
+
+    /// Returns the starting position, in bytes, of the header of this entry in
+    /// the archive.
+    ///
+    /// The header is always a contiguous section of 512 bytes, so if the
+    /// underlying reader implements `Seek`, then the slice from `header_pos` to
+    /// `header_pos + 512` contains the raw header bytes.
+    pub fn raw_header_position(&self) -> u64 {
+        self.fields.header_pos
+    }
+
+    /// Returns the starting position, in bytes, of the file of this entry in
+    /// the archive.
+    ///
+    /// If the file of this entry is continuous (e.g. not a sparse file), and
+    /// if the underlying reader implements `Seek`, then the slice from
+    /// `file_pos` to `file_pos + entry_size` contains the raw file bytes.
+    pub fn raw_file_position(&self) -> u64 {
+        self.fields.file_pos
     }
 
     /// Writes this file to the specified location.


### PR DESCRIPTION
Implement methods on `Entry` for querying the raw byte positions of the entry's header and file within the archive.

The main motivation is that there are cases when the `Read` object passed to `Archive` implements `Seek` or is simply byte-sliceable, and we want to perform random access on individual entries of the archive. A concrete example is a large memory mapped tar file, for which we want to avoid unnecessary copies through `Read`.

This commit does what seems to be the least invasive thing to achieve the above: (1) adding two helper methods to `Entry` for querying the raw byte positions of the header and file, and (2) putting the responsibility to the user for figuring out whether it is valid to use the raw byte representations (e.g. when the entry type is not a sparse file).