### PR TITLE
Include file mode in items filtered for deterministic headers

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -636,7 +636,7 @@ impl Header {
                 self.set_uid(0);
                 self.set_gid(0);
 
-                // Use a default umask value, but propogate the (user) execute bit.
+                // Use a default umask value, but propagate the (user) execute bit.
                 let fs_mode =
                   if meta.is_dir() || (0o100 & meta.mode() == 0o100) {
                     0o755

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::Path;
 use std::{iter, thread, time};
@@ -159,21 +159,26 @@ fn set_metadata_deterministic() {
     let td = t!(TempDir::new("tar-rs"));
     let tmppath = td.path().join("tmpfile");
 
-    fn mk_header(path: &Path) -> Result<Header, io::Error> {
-      t!(t!(File::create(path)).write_all(b"c"));
+    fn mk_header(path: &Path, readonly: bool) -> Result<Header, io::Error> {
+      let mut file = t!(File::create(path));
+      t!(file.write_all(b"c"));
+      let mut perms = t!(file.metadata()).permissions();
+      perms.set_readonly(readonly);
+      t!(fs::set_permissions(path, perms));
       let mut h = Header::new_ustar();
       h.set_metadata_in_mode(&t!(path.metadata()), HeaderMode::Deterministic);
       Ok(h)
     }
 
-    // Create "the same" File twice in a row, one second apart.
-    let one = t!(mk_header(tmppath.as_path()));
+    // Create "the same" File twice in a row, one second apart, with differing readonly values.
+    let one = t!(mk_header(tmppath.as_path(), false));
     thread::sleep(time::Duration::from_millis(1050));
-    let two = t!(mk_header(tmppath.as_path()));
+    let two = t!(mk_header(tmppath.as_path(), true));
 
     // Always expected to match.
     assert_eq!(t!(one.size()), t!(two.size()));
     assert_eq!(t!(one.path()), t!(two.path()));
+    assert_eq!(t!(one.mode()), t!(two.mode()));
 
     // Would not match without `Deterministic`.
     assert_eq!(t!(one.mtime()), t!(two.mtime()));


### PR DESCRIPTION
For our usecase of the `Deterministic` header mode, we're not interested in including anything except the `execute` bit of appended files (in particular, we're trying to align with what `git` persists for files). See https://github.com/pantsbuild/pants/issues/4610 for more color.

The change introduces a mask that drops all filemode information other than the type and the execute bit. It's possible that this could be considered a new Header mode, but I'd prefer to just change the behaviour of the existing `Deterministic` mode if that works for you.