### PR TITLE
It is valid for tar to contain ./ entry

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -1215,6 +1215,8 @@ fn copy_path_into(mut slot: &mut [u8],
             (Component::ParentDir, false) => {
                 return Err(other("paths in archives must not have `..`"))
             }
+            // Allow "./" as the path
+            (Component::CurDir, false) if path.components().count() == 1 => {},
             (Component::CurDir, false) => continue,
             (Component::Normal(_), _) |
             (_, true) => {}

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -370,8 +370,10 @@ fn extracting_malicious_tarball() {
         append("./../rel_evil3.txt");
         append("some/../../rel_evil4.txt");
         append("");
-        append("././//./");
-        append(".");
+        append("././//./..");
+        append("..");
+        append("/////////..");
+        append("/////////");
     }
 
     let mut ar = Archive::new(&evil_tar[..]);


### PR DESCRIPTION
Tar archives allow current directory to be an entry:

```sh
# tar cvf ../test.tar .
./
# tar tvf ../test.tar
drwxr-xr-x root/root         0 2017-08-01 00:31 ./
```

and this is needed by [cargo-deb](https://github.com/mmstick/cargo-deb/issues/2).

Cases such as `/./././foo/./././` don't have to be handled explicitly here, because they are normalized by `Path.components()` (they [parse as](https://play.rust-lang.org/?gist=7d8b78e79ff62ead1278926be51f1baa) `Components([CurDir, Normal("foo")])`). Just as a precaution I've added check to allow `CurDir` only if it's the one and only path component.

Fixes #69