### PR TITLE
Set correct mtime when creating header

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -145,6 +145,7 @@ impl Header {
             gnu.magic = *b"ustar ";
             gnu.version = *b" \0";
         }
+        header.set_mtime(0);
         header
     }
 
@@ -162,6 +163,7 @@ impl Header {
             gnu.magic = *b"ustar\0";
             gnu.version = *b"00";
         }
+        header.set_mtime(0);
         header
     }
 
@@ -172,7 +174,9 @@ impl Header {
     /// format limits the path name limit and isn't able to contain extra
     /// metadata like atime/ctime.
     pub fn new_old() -> Header {
-        Header { bytes: [0; 512] }
+        let mut header = Header { bytes: [0; 512] };
+        header.set_mtime(0);
+        header
     }
 
     fn is_ustar(&self) -> bool {

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -60,6 +60,18 @@ fn link_name() {
 }
 
 #[test]
+fn mtime() {
+    let h = Header::new_gnu();
+    assert_eq!(t!(h.mtime()), 0);
+
+    let h = Header::new_ustar();
+    assert_eq!(t!(h.mtime()), 0);
+
+    let h = Header::new_old();
+    assert_eq!(t!(h.mtime()), 0);
+}
+
+#[test]
 fn user_and_group_name() {
     let mut h = Header::new_gnu();
     t!(h.set_username("foo"));


### PR DESCRIPTION
This makes tar-rs produce default headers that are standards-compliant.