### PR TITLE
Travis: start testing for a minimum stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.10.0
 env:
   global:
     - RUSTFLAGS='-C link-dead-code'


### PR DESCRIPTION
We choose 1.10.0 as it is the lowest working one on linux.
On other targets, the ? operator is required in dependencies,
so the lowest working release for them is probably 1.15.1.
If this causes any issues in the future, the number can be changed
from 1.10.0 to 1.15.1.