### PR TITLE
deps: Update xattr to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ filetime = "0.1.5"
 tempdir = "0.3"
 
 [target."cfg(unix)".dependencies]
-xattr = { version = "0.1.7", optional = true }
+xattr = { version = "0.2", optional = true }
 libc = "0.2"
 
 [target.'cfg(target_os = "redox")'.dependencies]

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -201,19 +201,21 @@ fn xattrs() {
     t!(ar.unpack(td.path()));
 
     let val = xattr::get(td.path().join("a/b"), "user.pax.flags").unwrap();
-	assert_eq!(val, "epm".as_bytes());
+    assert_eq!(val.unwrap(), "epm".as_bytes());
 }
 
 #[test]
 #[cfg(all(unix, feature = "xattr"))]
 fn no_xattrs() {
-	let td = t!(TempDir::new("tar-rs"));
-	let rdr = Cursor::new(tar!("xattrs.tar"));
-	let mut ar = Archive::new(rdr);
+    // If /tmp is a tmpfs, xattr will fail
+    // The xattr crate's unit tests also use /var/tmp for this reason
+    let td = t!(TempDir::new_in("/var/tmp", "tar-rs"));
+    let rdr = Cursor::new(tar!("xattrs.tar"));
+    let mut ar = Archive::new(rdr);
     ar.set_unpack_xattrs(false);
-	t!(ar.unpack(td.path()));
+    t!(ar.unpack(td.path()));
 
-	xattr::get(td.path().join("a/b"), "user.pax.flags").unwrap_err();
+    assert_eq!(xattr::get(td.path().join("a/b"), "user.pax.flags").unwrap(), None);
 }
 
 #[test]


### PR DESCRIPTION
get() used to return Result<Vec<u8>> which was indicating problem
either with getting attributes or those attributes being empty.
Now it returns Result<Option<Vec<u8>>> where Result is for reporting
problems with getting attrs and Option for showing whether attrs are
empty.

Then make sure that no_xattrs test is really trying to test something.

And also make indent to be consistent.

Signed-off-by: Igor Gnatenko <ignatenkobrain@fedoraproject.org>