### PR TITLE
Always write big-endian in numeric_extended_into

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -1422,7 +1422,7 @@ fn numeric_extended_into(dst: &mut [u8], src: u64) {
     let len: usize = dst.len();
     for (slot, val) in dst.iter_mut().zip(
         repeat(0).take(len - 8) // to zero init extra bytes
-            .chain((0..8).map(|x| ((src.to_be() >> (8 * x)) & 0xff) as u8)),
+            .chain((0..8).rev().map(|x| ((src >> (8 * x)) & 0xff) as u8)),
     ) {
         *slot = val;
     }


### PR DESCRIPTION
Before, this was transforming the number `to_be()`, then pulling out
least-significant bytes at shr 0, 8, 16, etc.  This has the effect of
writing reversed bytes on a little-endian target.  But since `to_be()`
does nothing on actual big-endian machines, they end up incorrectly
writing the true least-significant bytes first.

Instead, we can just reverse the order of the shift indexes, and then
the platform endianness is irrelevant.

Fixes #161.