### PR TITLE
Strict entries for out of order processing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.21.0
+  - 1.26.0
 env:
   global:
     - RUSTFLAGS='-C link-dead-code'

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,8 +1,10 @@
 use std::cell::{Cell, RefCell};
 use std::cmp;
 use std::io;
+use std::io::Cursor;
 use std::io::prelude::*;
 use std::path::Path;
+use std::iter::Iterator;
 
 use entry::{EntryFields, EntryIo, EntryBlockIo, ExactTake};
 use error::TarError;
@@ -58,6 +60,14 @@ impl<R: Read> Archive<R> {
     pub fn entries(&mut self) -> io::Result<Entries> {
         let me: &mut Archive<Read> = self;
         me._entries()
+    }
+
+    /// Construct a strict iterator over the entries in this archive.
+    ///
+    /// Entries can be stored and processed out of order, in contrast to `Archive::entries`.
+    /// Note that each strict entry stores the file's data in memory.
+    pub fn strict_entries<'a>(&'a mut self) -> io::Result< impl Iterator<Item=io::Result<Entry<Cursor<Vec<u8>>>>> + 'a > {
+        Ok(self.entries()?.map(|e| e?.force()))
     }
 
     /// Unpacks the contents tarball into the specified `dst`.

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -158,7 +158,7 @@ impl<'a> Entries<'a> {
 }
 
 impl<'a> Entries<'a> {
-    fn next_entry_raw(&mut self) -> io::Result<Option<Entry<'a>>> {
+    fn next_entry_raw(&mut self) -> io::Result<Option<Entry<&'a ArchiveInner<Read + 'a>>>> {
         // Seek to the start of the next header in the archive
         let delta = self.next - self.archive.inner.pos.get();
         self.archive.skip(delta)?;
@@ -219,7 +219,7 @@ impl<'a> Entries<'a> {
         Ok(Some(ret.into_entry()))
     }
 
-    fn next_entry(&mut self) -> io::Result<Option<Entry<'a>>> {
+    fn next_entry(&mut self) -> io::Result<Option<Entry<&'a ArchiveInner<Read + 'a>>>> {
         if self.raw {
             return self.next_entry_raw();
         }
@@ -285,7 +285,7 @@ impl<'a> Entries<'a> {
         }
     }
 
-    fn parse_sparse_header(&mut self, entry: &mut EntryFields<'a>) -> io::Result<()> {
+    fn parse_sparse_header(&mut self, entry: &mut EntryFields<&'a ArchiveInner<Read + 'a>>) -> io::Result<()> {
         if !entry.header.entry_type().is_gnu_sparse() {
             return Ok(());
         }
@@ -387,9 +387,9 @@ impl<'a> Entries<'a> {
 }
 
 impl<'a> Iterator for Entries<'a> {
-    type Item = io::Result<Entry<'a>>;
+    type Item = io::Result<Entry<&'a ArchiveInner<Read + 'a>>>;
 
-    fn next(&mut self) -> Option<io::Result<Entry<'a>>> {
+    fn next(&mut self) -> Option<io::Result<Entry<&'a ArchiveInner<Read + 'a>>>> {
         if self.done {
             None
         } else {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -258,7 +258,7 @@ impl<W: Write> Builder<W> {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use std::fs;
     /// use tar::Builder;
     ///

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::cmp;
 use std::fs;
 use std::io::prelude::*;
-use std::io::{self, Error, ErrorKind};
+use std::io::{self, Error, ErrorKind, Cursor};
 use std::path::{Component, Path, PathBuf};
 
 use filetime::{self, FileTime};
@@ -227,7 +227,7 @@ impl<R: Read> Entry<R> {
     ///
     /// let mut ar = Archive::new(File::open("foo.tar").unwrap());
     ///
-    /// for (i, file) in ar.entries().unwrap().enumerate() {
+    /// for file in ar.entries().unwrap() {
     ///     let mut file = file.unwrap();
     ///     file.unpack_in("target").unwrap();
     /// }
@@ -235,6 +235,45 @@ impl<R: Read> Entry<R> {
     pub fn unpack_in<P: AsRef<Path>>(&mut self, dst: P) -> io::Result<bool> {
         self.fields.unpack_in(dst.as_ref())
     }
+
+    /// Reads the file's data into memory, making an Entry independent of the Archive's reader.
+    ///
+    /// This allows out of order proccessing of entries, unlike the entries returned from `Archive::entries`.
+    /// Strict Entries also implement `Send` - allowing concurrent processing of tar Entries.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::fs::File;
+    /// use tar::Archive;
+    ///
+    /// let mut ar = Archive::new(File::open("foo.tar")?);
+    /// let mut entries = ar.entries()?;
+    ///
+    /// let entry1 = entries.next()??.force()?;
+    /// let entry2 = entries.next()??.force()?;
+    /// entry2.unpack_in("target")?;
+    /// entry1.unpack_in("target")?;
+    /// ```
+    pub fn force(mut self) -> io::Result<Entry<Cursor<Vec<u8>>>> {
+        let entry_data: Vec<u8> = self.fields.read_all()?;
+        Ok (Entry {
+            fields: EntryFields {
+                data: Cursor::new(entry_data),
+
+                long_pathname: self.fields.long_pathname,
+                long_linkname: self.fields.long_linkname,
+                pax_extensions: self.fields.pax_extensions,
+                header: self.fields.header,
+                size: self.fields.size,
+                header_pos: self.fields.header_pos,
+                file_pos: self.fields.file_pos,
+                unpack_xattrs: self.fields.unpack_xattrs,
+                preserve_permissions: self.fields.preserve_permissions,
+            }
+        })
+    }
+
 }
 
 impl<R> ExactTake<R> {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -596,7 +596,7 @@ impl<R: Read> EntryFields<R> {
         }
 
         #[cfg(all(unix, feature = "xattr"))]
-        fn set_xattrs<T>(me: &mut EntryFields<T>, dst: &Path) -> io::Result<()> {
+        fn set_xattrs<T: Read>(me: &mut EntryFields<T>, dst: &Path) -> io::Result<()> {
             use std::ffi::OsStr;
             use std::os::unix::prelude::*;
             use xattr;

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,7 @@ impl error::Error for TarError {
 
 impl fmt::Display for TarError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.desc.fmt(f)
+        write!(f, "{} - {}", self.desc, self.io)
     }
 }
 


### PR DESCRIPTION
Hi there.
This pull request exposes 2 new surface-level functions:
1. `Entry::force` - forces an Entry - reading it's contents into memory, allowing it's processing (unpack) in an out-of-order fashion.
2. `Archive::strict_entries` - provides an iterator of forced/strict entries.

This PR also refactors the internal code a bit to allow for this change.
- There's a change that separates the functions on `Entry` to those which require `Read` and those that don't, which clutters the diff a little bit.

Fixes #160 