### PR TITLE
Add two new methods to tar Builder: inner_ref and flush_inner.

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -60,6 +60,16 @@ impl<W: Write> Builder<W> {
         Ok(self.obj.take().unwrap())
     }
 
+    /// Gets shared reference to the underlying object.
+    pub fn inner_ref(&self) -> &W {
+        self.obj.as_ref().unwrap()
+    }
+
+    /// Flushes the underlying object.
+    pub fn flush_inner(&mut self) -> io::Result<()> {
+        self.obj.as_mut().unwrap().flush()
+    }
+
     /// Adds a new entry to this archive.
     ///
     /// This function will append the header specified, followed by contents of


### PR DESCRIPTION
These methods are useful while working with tar.gz:

- `inner_ref` allows to get current size of gzipped archive;

- `flush_inner` ensures that tar entry was written (look at [test](https://github.com/alexcrichton/tar-rs/compare/master...nickkuk:master#diff-1af2312a884fedee3dfc165a03ecfdd6R165)).