### PR TITLE
builder: handle long link names

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -410,11 +410,11 @@ impl Header {
         }
     }
 
-    /// Sets the path name for this header.
+    /// Sets the link name for this header.
     ///
-    /// This function will set the pathname listed in this header, encoding it
-    /// in the appropriate format. May fail if the path is too long or if the
-    /// path specified is not unicode and this is a Windows platform.
+    /// This function will set the linkname listed in this header, encoding it
+    /// in the appropriate format. May fail if the link name is too long or if
+    /// the path specified is not unicode and this is a Windows platform.
     pub fn set_link_name<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
         self._set_link_name(p.as_ref())
     }


### PR DESCRIPTION
As already implemented for long path names, handle packing long link with the
GNU extension (entry type 'K') in append_fs function.