### PR TITLE
Some time of check/time of use bugfixes

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::cmp;
 use std::fs;
+use std::fs::OpenOptions;
 use std::io::prelude::*;
 use std::io::{self, Error, ErrorKind, SeekFrom};
 use std::marker;
@@ -522,16 +523,23 @@ impl<'a> EntryFields<'a> {
         // As a result if we don't recognize the kind we just write out the file
         // as we would normally.
 
-        // Remove an existing file, if any, to avoid writing through
-        // symlinks/hardlinks to weird locations. The tar archive says this is a
-        // regular file, so let's make it a regular file.
+        // Ensure we write a new file rather than overwriting in-place which
+        // is attackable; if an existing file is found unlink it.
+        fn open(dst: &Path) -> io::Result<std::fs::File> {
+            OpenOptions::new().write(true).create_new(true).open(dst)
+        };
         (|| -> io::Result<()> {
-            match fs::remove_file(dst) {
-                Ok(()) => {}
-                Err(ref e) if e.kind() == io::ErrorKind::NotFound => {}
-                Err(e) => return Err(e),
-            }
-            let mut f = fs::File::create(dst)?;
+            let mut f = open(dst).or_else(|err| {
+                if err.kind() != ErrorKind::AlreadyExists {
+                    Err(err)
+                } else {
+                    match fs::remove_file(dst) {
+                        Ok(()) => open(dst),
+                        Err(ref e) if e.kind() == io::ErrorKind::NotFound => open(dst),
+                        Err(e) => Err(e),
+                    }
+                }
+            })?;
             for io in self.data.drain(..) {
                 match io {
                     EntryIo::Data(mut d) => {


### PR DESCRIPTION
As described in bug #198 there are attack vectors in tar-rs at the moment. This patch corrects the worst of them, but doesn't go the whole way - changes to Filetime would be needed (or just not using that API at all) and I figured a discussion about that would make sense before going further.