### PR TITLE
WIP: Eliminate readonly syscalls for files on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ contents are never required to be entirely resident in memory all at once.
 """
 
 [dependencies]
-filetime = "0.2"
+filetime = "0.2.6"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ tempdir = "0.3"
 xattr = { version = "0.2", optional = true }
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["winnt"] }
+
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.1"
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -573,7 +573,7 @@ impl<'a> EntryFields<'a> {
         if self.preserve_mtime {
             if let Ok(mtime) = self.header.mtime() {
                 let mtime = FileTime::from_unix_time(mtime as i64, 0);
-                filetime::set_file_times(dst, mtime, mtime).map_err(|e| {
+                filetime::set_file_handle_times(&f, Some(mtime), Some(mtime)).map_err(|e| {
                     TarError::new(&format!("failed to set mtime for `{}`", dst.display()), e)
                 })?;
             }

--- a/src/header.rs
+++ b/src/header.rs
@@ -781,6 +781,7 @@ impl Header {
 
     #[cfg(windows)]
     fn fill_platform_from(&mut self, meta: &fs::Metadata, mode: HeaderMode) {
+        use winapi::um::winnt::FILE_ATTRIBUTE_READONLY;
         // There's no concept of a file mode on windows, so do a best approximation here.
         match mode {
             HeaderMode::Complete => {
@@ -793,7 +794,6 @@ impl Header {
                 let mtime = (meta.last_write_time() / (1_000_000_000 / 100)) - 11644473600;
                 self.set_mtime(mtime);
                 let fs_mode = {
-                    const FILE_ATTRIBUTE_READONLY: u32 = 0x00000001;
                     let readonly = meta.file_attributes() & FILE_ATTRIBUTE_READONLY;
                     match (meta.is_dir(), readonly != 0) {
                         (true, false) => 0o755,


### PR DESCRIPTION
The Windows API permits files to be created with the desired attributes
rather than setting them via a later syscall.

This is already exposed in Rust via the std::os modules. I can add a use of winapi for the
constant if desired.

This is a follow-on to #201 - they textually conflict or I would have made this fully standalone.