### PR TITLE
Return the File instance from Entry::unpack

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use std::io::{Error, ErrorKind};
 
 pub use crate::archive::{Archive, Entries};
 pub use crate::builder::Builder;
-pub use crate::entry::Entry;
+pub use crate::entry::{Entry, Unpacked};
 pub use crate::entry_type::EntryType;
 pub use crate::header::GnuExtSparseHeader;
 pub use crate::header::{GnuHeader, GnuSparseHeader, Header, HeaderMode, OldHeader, UstarHeader};


### PR DESCRIPTION
 This permits optimisation of unpacking on Windows - which is perhaps
overly special cased to include in tar itself? Doing this for rustup
which already doesn't use the Archive wrapper :/.

With this patch, I reduced rustup's rust-docs install from 21/22s to
11s on my bench machine - details at
rust-lang/rustup.rs#1850

I haven't filled in all the possibilities for the Unpacked enum, but
happy to do so if you'd like that done - it seemed like it wouldn't
be useful at this stage as there are no live objects to return.

Follow on patch from https://github.com/alexcrichton/tar-rs/pull/202 - again, text conflicts or I would have made them standalone.