### PR TITLE
Bug #198: Set mtime and atime on file handles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ contents are never required to be entirely resident in memory all at once.
 """
 
 [dependencies]
-filetime = "0.2"
+filetime = "0.2.6"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -573,7 +573,7 @@ impl<'a> EntryFields<'a> {
         if self.preserve_mtime {
             if let Ok(mtime) = self.header.mtime() {
                 let mtime = FileTime::from_unix_time(mtime as i64, 0);
-                filetime::set_file_times(dst, mtime, mtime).map_err(|e| {
+                filetime::set_file_handle_times(&f, Some(mtime), Some(mtime)).map_err(|e| {
                     TarError::new(&format!("failed to set mtime for `{}`", dst.display()), e)
                 })?;
             }


### PR DESCRIPTION
For unix systems this should be marginally more efficient; for
Windows systems a whole open/close pair is avoided, which can make
significant savings when dealing with many files.