### PR TITLE
Avoid unneeded readonly syscalls on Windows

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -620,15 +620,18 @@ impl<'a> EntryFields<'a> {
             mode: u32,
             _preserve: bool,
         ) -> io::Result<()> {
+            if mode & 0o200 == 0o200 {
+                return Ok(());
+            }
             match f {
                 Some(f) => {
                     let mut perm = f.metadata()?.permissions();
-                    perm.set_readonly(mode & 0o200 != 0o200);
+                    perm.set_readonly(true);
                     f.set_permissions(perm)
                 }
                 None => {
                     let mut perm = fs::metadata(dst)?.permissions();
-                    perm.set_readonly(mode & 0o200 != 0o200);
+                    perm.set_readonly(true);
                     fs::set_permissions(dst, perm)
                 }
             }


### PR DESCRIPTION
This meets the rustup use case (less syscalls) but not the general use case (unpacking a huge tar with many readonly files will be slower than a huge tar with many writable files)