### PR TITLE
Permit ignoring entry permissions

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -22,6 +22,7 @@ pub struct ArchiveInner<R: ?Sized> {
     unpack_xattrs: bool,
     preserve_permissions: bool,
     preserve_mtime: bool,
+    ignore_permissions: bool,
     ignore_zeros: bool,
     obj: RefCell<R>,
 }
@@ -47,6 +48,7 @@ impl<R: Read> Archive<R> {
                 unpack_xattrs: false,
                 preserve_permissions: false,
                 preserve_mtime: true,
+                ignore_permissions: false,
                 ignore_zeros: false,
                 obj: RefCell::new(obj),
                 pos: Cell::new(0),
@@ -123,6 +125,15 @@ impl<R: Read> Archive<R> {
     /// This flag is enabled by default.
     pub fn set_preserve_mtime(&mut self, preserve: bool) {
         self.inner.preserve_mtime = preserve;
+    }
+
+    /// Indicate whether any permissions (like exec/readonly/suid on Unix) are set
+    /// when unpacking this entry.
+    ///
+    /// This flag is disabled by default. When enabled all files will be unpacked
+    /// and the final chmod after extracting content entirely skipped.
+    pub fn set_ignore_permissions(&mut self, ignore: bool) {
+        self.inner.ignore_permissions = ignore;
     }
 
     /// Ignore zeroed headers, which would otherwise indicate to the archive that it has no more
@@ -255,6 +266,7 @@ impl<'a> EntriesFields<'a> {
             unpack_xattrs: self.archive.inner.unpack_xattrs,
             preserve_permissions: self.archive.inner.preserve_permissions,
             preserve_mtime: self.archive.inner.preserve_mtime,
+            ignore_permissions: self.archive.inner.ignore_permissions,
         };
 
         // Store where the next entry is, rounding up by 512 bytes (the size of

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -40,6 +40,7 @@ pub struct EntryFields<'a> {
     pub unpack_xattrs: bool,
     pub preserve_permissions: bool,
     pub preserve_mtime: bool,
+    pub ignore_permissions: bool,
 }
 
 pub enum EntryIo<'a> {
@@ -249,6 +250,15 @@ impl<'a, R: Read> Entry<'a, R> {
     pub fn set_preserve_mtime(&mut self, preserve: bool) {
         self.fields.preserve_mtime = preserve;
     }
+
+    /// Indicate whether any permissions (like exec/readonly/suid on Unix) are set
+    /// when unpacking this entry.
+    ///
+    /// This flag is disabled by default. When enabled all files will be unpacked
+    /// and the final chmod after extracting content entirely skipped.
+    pub fn set_ignore_permissions(&mut self, ignore: bool) {
+        self.fields.ignore_permissions = ignore;
+    }
 }
 
 impl<'a, R: Read> Read for Entry<'a, R> {
@@ -431,7 +441,7 @@ impl<'a> EntryFields<'a> {
         if kind.is_dir() {
             self.unpack_dir(dst)?;
             if let Ok(mode) = self.header.mode() {
-                set_perms(dst, None, mode, self.preserve_permissions)?;
+                set_perms(dst, None, mode, self.preserve_permissions, self.ignore_permissions)?;
             }
             return Ok(Unpacked::__Nonexhaustive);
         } else if kind.is_hard_link() || kind.is_symlink() {
@@ -527,7 +537,7 @@ impl<'a> EntryFields<'a> {
         if self.header.as_ustar().is_none() && self.path_bytes().ends_with(b"/") {
             self.unpack_dir(dst)?;
             if let Ok(mode) = self.header.mode() {
-                set_perms(dst, None, mode, self.preserve_permissions)?;
+                set_perms(dst, None, mode, self.preserve_permissions, self.ignore_permissions)?;
             }
             return Ok(Unpacked::__Nonexhaustive);
         }
@@ -597,7 +607,7 @@ impl<'a> EntryFields<'a> {
             }
         }
         if let Ok(mode) = self.header.mode() {
-            set_perms(dst, Some(&mut f), mode, self.preserve_permissions)?;
+            set_perms(dst, Some(&mut f), mode, self.preserve_permissions, self.ignore_permissions)?;
         }
         if self.unpack_xattrs {
             set_xattrs(self, dst)?;
@@ -609,7 +619,11 @@ impl<'a> EntryFields<'a> {
             f: Option<&mut std::fs::File>,
             mode: u32,
             preserve: bool,
+            ignore: bool,
         ) -> Result<(), TarError> {
+            if ignore {
+                return Ok(())
+            }
             _set_perms(dst, f, mode, preserve).map_err(|e| {
                 TarError::new(
                     &format!(


### PR DESCRIPTION
Sometimes the extractor will know exactly what permissions they
want, in which case having to re-chmod things just adds latency
to the operation. HPC file systems in particular appear to be
extra-ordinarily slow at metadata operations (~1-2ms per inode).