### PR TITLE
workflows: fix Windows pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,12 @@ jobs:
             rust: stable
     steps:
     - uses: actions/checkout@master
+    - name: Install Rust (windows)
+      run: (rustup update ${{ matrix.rust }} --no-self-update) -and (rustup default ${{ matrix.rust }})
+      if: matrix.os == 'windows-latest'
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-      if: matrix.os != 'macos-latest'
+      if: matrix.os == 'ubuntu-latest'
     - name: Install Rust (macos)
       run: |
         curl https://sh.rustup.rs | sh -s -- -y

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       run: (rustup update ${{ matrix.rust }} --no-self-update) -and (rustup default ${{ matrix.rust }})
       if: matrix.os == 'windows-latest'
     - name: Install Rust (rustup)
-      run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       if: matrix.os == 'ubuntu-latest'
     - name: Install Rust (macos)
       run: |


### PR DESCRIPTION
The `&&` syntax is not supported in PowerShell. See
PowerShell/PowerShell#9849.