### PR TITLE
Migrate tempdir dependency to tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ contents are never required to be entirely resident in memory all at once.
 filetime = "0.2.6"
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "3"
 
 [target."cfg(unix)".dependencies]
 xattr = { version = "0.2", optional = true }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1579,12 +1579,11 @@ pub fn path2bytes(p: &Path) -> io::Result<Cow<[u8]>> {
 pub fn bytes2path(bytes: Cow<[u8]>) -> io::Result<Cow<Path>> {
     return match bytes {
         Cow::Borrowed(bytes) => {
-            let s = r#try!(str::from_utf8(bytes).map_err(|_| not_unicode(bytes)));
+            let s = str::from_utf8(bytes).map_err(|_| not_unicode(bytes))?;
             Ok(Cow::Borrowed(Path::new(s)))
         }
         Cow::Owned(bytes) => {
-            let s =
-                r#try!(String::from_utf8(bytes).map_err(|uerr| not_unicode(&uerr.into_bytes())));
+            let s = String::from_utf8(bytes).map_err(|uerr| not_unicode(&uerr.into_bytes()))?;
             Ok(Cow::Owned(PathBuf::from(s)))
         }
     };

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1,6 +1,6 @@
 extern crate filetime;
 extern crate tar;
-extern crate tempdir;
+extern crate tempfile;
 #[cfg(all(unix, feature = "xattr"))]
 extern crate xattr;
 
@@ -10,9 +10,9 @@ use std::io::{self, Cursor};
 use std::iter::repeat;
 use std::path::{Path, PathBuf};
 
-use self::tempdir::TempDir;
 use filetime::FileTime;
 use tar::{Archive, Builder, EntryType, Header};
+use tempfile::{Builder as TempBuilder,TempDir};
 
 macro_rules! t {
     ($e:expr) => {
@@ -132,7 +132,7 @@ fn reading_files() {
 #[test]
 fn writing_files() {
     let mut ar = Builder::new(Vec::new());
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let path = td.path().join("test");
     t!(t!(File::create(&path)).write_all(b"test"));
@@ -156,7 +156,7 @@ fn writing_files() {
 #[test]
 fn large_filename() {
     let mut ar = Builder::new(Vec::new());
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let path = td.path().join("test");
     t!(t!(File::create(&path)).write_all(b"test"));
@@ -236,7 +236,7 @@ fn check_dirtree(td: &TempDir) {
 
 #[test]
 fn extracting_directories() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let rdr = Cursor::new(tar!("directory.tar"));
     let mut ar = Archive::new(rdr);
     t!(ar.unpack(td.path()));
@@ -248,7 +248,7 @@ fn extracting_directories() {
 fn xattrs() {
     // If /tmp is a tmpfs, xattr will fail
     // The xattr crate's unit tests also use /var/tmp for this reason
-    let td = t!(TempDir::new_in("/var/tmp", "tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir_in("/var/tmp"));
     let rdr = Cursor::new(tar!("xattrs.tar"));
     let mut ar = Archive::new(rdr);
     ar.set_unpack_xattrs(true);
@@ -263,7 +263,7 @@ fn xattrs() {
 fn no_xattrs() {
     // If /tmp is a tmpfs, xattr will fail
     // The xattr crate's unit tests also use /var/tmp for this reason
-    let td = t!(TempDir::new_in("/var/tmp", "tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir_in("/var/tmp"));
     let rdr = Cursor::new(tar!("xattrs.tar"));
     let mut ar = Archive::new(rdr);
     ar.set_unpack_xattrs(false);
@@ -277,7 +277,7 @@ fn no_xattrs() {
 
 #[test]
 fn writing_and_extracting_directories() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let mut ar = Builder::new(Vec::new());
     let tmppath = td.path().join("tmpfile");
@@ -295,7 +295,7 @@ fn writing_and_extracting_directories() {
 
 #[test]
 fn writing_directories_recursively() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let base_dir = td.path().join("base");
     t!(fs::create_dir(&base_dir));
@@ -326,7 +326,7 @@ fn writing_directories_recursively() {
 
 #[test]
 fn append_dir_all_blank_dest() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let base_dir = td.path().join("base");
     t!(fs::create_dir(&base_dir));
@@ -357,7 +357,7 @@ fn append_dir_all_blank_dest() {
 
 #[test]
 fn append_dir_all_does_not_work_on_non_directory() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let path = td.path().join("test");
     t!(t!(File::create(&path)).write_all(b"test"));
 
@@ -368,7 +368,7 @@ fn append_dir_all_does_not_work_on_non_directory() {
 
 #[test]
 fn extracting_duplicate_dirs() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let rdr = Cursor::new(tar!("duplicate_dirs.tar"));
     let mut ar = Archive::new(rdr);
     t!(ar.unpack(td.path()));
@@ -379,7 +379,7 @@ fn extracting_duplicate_dirs() {
 
 #[test]
 fn unpack_old_style_bsd_dir() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let mut ar = Builder::new(Vec::new());
 
@@ -405,7 +405,7 @@ fn unpack_old_style_bsd_dir() {
 
 #[test]
 fn handling_incorrect_file_size() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let mut ar = Builder::new(Vec::new());
 
@@ -432,7 +432,7 @@ fn handling_incorrect_file_size() {
 
 #[test]
 fn extracting_malicious_tarball() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let mut evil_tar = Vec::new();
 
@@ -530,7 +530,7 @@ fn octal_spaces() {
 
 #[test]
 fn extracting_malformed_tar_null_blocks() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let mut ar = Builder::new(Vec::new());
 
@@ -553,7 +553,7 @@ fn extracting_malformed_tar_null_blocks() {
 
 #[test]
 fn empty_filename() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let rdr = Cursor::new(tar!("empty_filename.tar"));
     let mut ar = Archive::new(rdr);
     assert!(ar.unpack(td.path()).is_ok());
@@ -561,7 +561,7 @@ fn empty_filename() {
 
 #[test]
 fn file_times() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let rdr = Cursor::new(tar!("file_times.tar"));
     let mut ar = Archive::new(rdr);
     t!(ar.unpack(td.path()));
@@ -578,7 +578,7 @@ fn file_times() {
 #[test]
 fn backslash_treated_well() {
     // Insert a file into an archive with a backslash
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let mut ar = Builder::new(Vec::<u8>::new());
     t!(ar.append_dir("foo\\bar", td.path()));
     let mut ar = Archive::new(Cursor::new(t!(ar.into_inner())));
@@ -616,7 +616,7 @@ fn nul_bytes_in_path() {
     use std::os::unix::prelude::*;
 
     let nul_path = OsStr::from_bytes(b"foo\0");
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let mut ar = Builder::new(Vec::<u8>::new());
     let err = ar.append_dir(nul_path, td.path()).unwrap_err();
     assert!(err.to_string().contains("contains a nul byte"));
@@ -638,7 +638,7 @@ fn links() {
 #[test]
 #[cfg(unix)] // making symlinks on windows is hard
 fn unpack_links() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let mut ar = Archive::new(Cursor::new(tar!("link.tar")));
     t!(ar.unpack(td.path()));
 
@@ -732,7 +732,7 @@ fn long_linkname_trailing_nul() {
 
 #[test]
 fn encoded_long_name_has_trailing_nul() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let path = td.path().join("foo");
     t!(t!(File::create(&path)).write_all(b"test"));
 
@@ -807,7 +807,7 @@ fn reading_sparse() {
 fn extract_sparse() {
     let rdr = Cursor::new(tar!("sparse.tar"));
     let mut ar = Archive::new(rdr);
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     t!(ar.unpack(td.path()));
 
     let mut s = String::new();
@@ -847,7 +847,7 @@ fn extract_sparse() {
 #[test]
 fn path_separators() {
     let mut ar = Builder::new(Vec::new());
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let path = td.path().join("test");
     t!(t!(File::create(&path)).write_all(b"test"));
@@ -895,7 +895,7 @@ fn append_path_symlink() {
 
     let mut ar = Builder::new(Vec::new());
     ar.follow_symlinks(false);
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let long_linkname = repeat("abcd").take(30).collect::<String>();
     let long_pathname = repeat("dcba").take(30).collect::<String>();
@@ -943,7 +943,7 @@ fn append_path_symlink() {
 
 #[test]
 fn name_with_slash_doesnt_fool_long_link_and_bsd_compat() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
 
     let mut ar = Builder::new(Vec::new());
 
@@ -977,7 +977,7 @@ fn name_with_slash_doesnt_fool_long_link_and_bsd_compat() {
 #[test]
 fn insert_local_file_different_name() {
     let mut ar = Builder::new(Vec::new());
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let path = td.path().join("directory");
     t!(fs::create_dir(&path));
     ar.append_path_with_name(&path, "archive/dir").unwrap();
@@ -1000,8 +1000,8 @@ fn insert_local_file_different_name() {
 fn tar_directory_containing_symlink_to_directory() {
     use std::os::unix::fs::symlink;
 
-    let td = t!(TempDir::new("tar-rs"));
-    let dummy_src = t!(TempDir::new("dummy_src"));
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
+    let dummy_src = t!(TempBuilder::new().prefix("dummy_src").tempdir());
     let dummy_dst = td.path().join("dummy_dst");
     let mut ar = Builder::new(Vec::new());
     t!(symlink(dummy_src.path().display().to_string(), &dummy_dst));

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 
 use filetime::FileTime;
 use tar::{Archive, Builder, EntryType, Header};
-use tempfile::{Builder as TempBuilder,TempDir};
+use tempfile::{Builder as TempBuilder, TempDir};
 
 macro_rules! t {
     ($e:expr) => {

--- a/tests/entry.rs
+++ b/tests/entry.rs
@@ -1,10 +1,10 @@
 extern crate tar;
-extern crate tempdir;
+extern crate tempfile;
 
 use std::fs::File;
 use std::io::Read;
 
-use tempdir::TempDir;
+use tempfile::Builder;
 
 macro_rules! t {
     ($e:expr) => {
@@ -30,7 +30,7 @@ fn absolute_symlink() {
     let bytes = t!(ar.into_inner());
     let mut ar = tar::Archive::new(&bytes[..]);
 
-    let td = t!(TempDir::new("tar"));
+    let td = t!(Builder::new().prefix("tar").tempdir());
     t!(ar.unpack(td.path()));
 
     t!(td.path().join("foo").symlink_metadata());
@@ -43,7 +43,7 @@ fn absolute_symlink() {
 
 #[test]
 fn absolute_hardlink() {
-    let td = t!(TempDir::new("tar"));
+    let td = t!(Builder::new().prefix("tar").tempdir());
     let mut ar = tar::Builder::new(Vec::new());
 
     let mut header = tar::Header::new_gnu();
@@ -92,7 +92,7 @@ fn relative_hardlink() {
     let bytes = t!(ar.into_inner());
     let mut ar = tar::Archive::new(&bytes[..]);
 
-    let td = t!(TempDir::new("tar"));
+    let td = t!(Builder::new().prefix("tar").tempdir());
     t!(ar.unpack(td.path()));
     t!(td.path().join("foo").metadata());
     t!(td.path().join("bar").metadata());
@@ -120,7 +120,7 @@ fn absolute_link_deref_error() {
     let bytes = t!(ar.into_inner());
     let mut ar = tar::Archive::new(&bytes[..]);
 
-    let td = t!(TempDir::new("tar"));
+    let td = t!(Builder::new().prefix("tar").tempdir());
     assert!(ar.unpack(td.path()).is_err());
     t!(td.path().join("foo").symlink_metadata());
     assert!(File::open(td.path().join("foo").join("bar")).is_err());
@@ -148,7 +148,7 @@ fn relative_link_deref_error() {
     let bytes = t!(ar.into_inner());
     let mut ar = tar::Archive::new(&bytes[..]);
 
-    let td = t!(TempDir::new("tar"));
+    let td = t!(Builder::new().prefix("tar").tempdir());
     assert!(ar.unpack(td.path()).is_err());
     t!(td.path().join("foo").symlink_metadata());
     assert!(File::open(td.path().join("foo").join("bar")).is_err());
@@ -172,7 +172,7 @@ fn directory_maintains_permissions() {
     let bytes = t!(ar.into_inner());
     let mut ar = tar::Archive::new(&bytes[..]);
 
-    let td = t!(TempDir::new("tar"));
+    let td = t!(Builder::new().prefix("tar").tempdir());
     t!(ar.unpack(td.path()));
     let f = t!(File::open(td.path().join("foo")));
     let md = t!(f.metadata());
@@ -210,7 +210,7 @@ fn modify_link_just_created() {
     let bytes = t!(ar.into_inner());
     let mut ar = tar::Archive::new(&bytes[..]);
 
-    let td = t!(TempDir::new("tar"));
+    let td = t!(Builder::new().prefix("tar").tempdir());
     t!(ar.unpack(td.path()));
 
     t!(File::open(td.path().join("bar/foo")));
@@ -241,7 +241,7 @@ fn parent_paths_error() {
     let bytes = t!(ar.into_inner());
     let mut ar = tar::Archive::new(&bytes[..]);
 
-    let td = t!(TempDir::new("tar"));
+    let td = t!(Builder::new().prefix("tar").tempdir());
     assert!(ar.unpack(td.path()).is_err());
     t!(td.path().join("foo").symlink_metadata());
     assert!(File::open(td.path().join("foo").join("bar")).is_err());
@@ -271,7 +271,7 @@ fn good_parent_paths_ok() {
     let bytes = t!(ar.into_inner());
     let mut ar = tar::Archive::new(&bytes[..]);
 
-    let td = t!(TempDir::new("tar"));
+    let td = t!(Builder::new().prefix("tar").tempdir());
     t!(ar.unpack(td.path()));
     t!(td.path().join("foo").join("bar").read_link());
     let dst = t!(td.path().join("foo").join("bar").canonicalize());
@@ -300,7 +300,7 @@ fn modify_hard_link_just_created() {
     let bytes = t!(ar.into_inner());
     let mut ar = tar::Archive::new(&bytes[..]);
 
-    let td = t!(TempDir::new("tar"));
+    let td = t!(Builder::new().prefix("tar").tempdir());
 
     let test = td.path().join("test");
     t!(File::create(&test));
@@ -335,7 +335,7 @@ fn modify_symlink_just_created() {
     let bytes = t!(ar.into_inner());
     let mut ar = tar::Archive::new(&bytes[..]);
 
-    let td = t!(TempDir::new("tar"));
+    let td = t!(Builder::new().prefix("tar").tempdir());
 
     let test = td.path().join("test");
     t!(File::create(&test));

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -3,7 +3,7 @@ use std::io::{self, Write};
 use std::path::Path;
 use std::{iter, mem, thread, time};
 
-use tempdir::TempDir;
+use tempfile::Builder;
 
 use tar::{GnuHeader, Header, HeaderMode};
 
@@ -168,7 +168,7 @@ fn set_ustar_path_hard() {
 
 #[test]
 fn set_metadata_deterministic() {
-    let td = t!(TempDir::new("tar-rs"));
+    let td = t!(Builder::new().prefix("tar-rs").tempdir());
     let tmppath = td.path().join("tmpfile");
 
     fn mk_header(path: &Path, readonly: bool) -> Result<Header, io::Error> {


### PR DESCRIPTION
The tempdir crate is deprecated and tempfile is recommended as a
successor by its developers.