### PR TITLE
Fix Windows ignoring preserve_permissions

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -645,9 +645,9 @@ impl<'a> EntryFields<'a> {
             dst: &Path,
             f: Option<&mut std::fs::File>,
             mode: u32,
-            _preserve: bool,
+            preserve: bool,
         ) -> io::Result<()> {
-            if mode & 0o200 == 0o200 {
+            if !preserve || mode & 0o200 == 0o200 {
                 return Ok(());
             }
             match f {


### PR DESCRIPTION
If you use `set_preserve_permissions` and set to `false`, Windows would completely ignore this and continuing adding the read-only flag.