### PR TITLE
Allow current directories in header paths

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -362,7 +362,8 @@ impl Header {
     ///
     /// This function will set the pathname listed in this header, encoding it
     /// in the appropriate format. May fail if the path is too long or if the
-    /// path specified is not Unicode and this is a Windows platform.
+    /// path specified is not Unicode and this is a Windows platform. Will
+    /// strip out any "." path component, which signifies the current directory.
     pub fn set_path<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
         self._set_path(p.as_ref())
     }
@@ -414,7 +415,8 @@ impl Header {
     ///
     /// This function will set the linkname listed in this header, encoding it
     /// in the appropriate format. May fail if the link name is too long or if
-    /// the path specified is not Unicode and this is a Windows platform.
+    /// the path specified is not Unicode and this is a Windows platform. Will
+    /// strip out any "." path component, which signifies the current directory.
     pub fn set_link_name<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
         self._set_link_name(p.as_ref())
     }

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -139,6 +139,12 @@ fn set_path() {
         assert_eq!(t!(h.path()).to_str(), Some("foo\\bar"));
     }
 
+    // set_path documentation explictly states it removes any ".", signfying the
+    // current directory, from the path. This test ensures that documented
+    // beavhior occurs
+    t!(h.set_path("./control"));
+    assert_eq!(t!(h.path()).to_str(), Some("control"));
+
     let long_name = iter::repeat("foo").take(100).collect::<String>();
     let medium1 = iter::repeat("foo").take(52).collect::<String>();
     let medium2 = iter::repeat("fo/").take(52).collect::<String>();


### PR DESCRIPTION
The current implementation removes any "current directories" from the
header path for a file. This change stops the removal to leave the path
as is.

This change adds a test to check for regression

Fixes #219 