### PR TITLE
Remove special casing for Redox

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -509,7 +509,7 @@ impl<'a> EntryFields<'a> {
                 ::std::os::windows::fs::symlink_file(src, dst)
             }
 
-            #[cfg(any(unix, target_os = "redox"))]
+            #[cfg(unix)]
             fn symlink(src: &Path, dst: &Path) -> io::Result<()> {
                 ::std::os::unix::fs::symlink(src, dst)
             }
@@ -623,7 +623,7 @@ impl<'a> EntryFields<'a> {
             })
         }
 
-        #[cfg(any(unix, target_os = "redox"))]
+        #[cfg(unix)]
         fn _set_perms(
             dst: &Path,
             f: Option<&mut std::fs::File>,
@@ -717,12 +717,7 @@ impl<'a> EntryFields<'a> {
         }
         // Windows does not completely support posix xattrs
         // https://en.wikipedia.org/wiki/Extended_file_attributes#Windows_NT
-        #[cfg(any(
-            windows,
-            target_os = "redox",
-            not(feature = "xattr"),
-            target_arch = "wasm32"
-        ))]
+        #[cfg(any(windows, not(feature = "xattr"), target_arch = "wasm32"))]
         fn set_xattrs(_: &mut EntryFields, _: &Path) -> io::Result<()> {
             Ok(())
         }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,4 +1,4 @@
-#[cfg(any(unix, target_os = "redox"))]
+#[cfg(unix)]
 use std::os::unix::prelude::*;
 #[cfg(windows)]
 use std::os::windows::prelude::*;
@@ -719,7 +719,7 @@ impl Header {
         unimplemented!();
     }
 
-    #[cfg(any(unix, target_os = "redox"))]
+    #[cfg(unix)]
     fn fill_platform_from(&mut self, meta: &fs::Metadata, mode: HeaderMode) {
         match mode {
             HeaderMode::Complete => {
@@ -756,7 +756,6 @@ impl Header {
         // TODO: need to bind more file types
         self.set_entry_type(entry_type(meta.mode()));
 
-        #[cfg(not(target_os = "redox"))]
         fn entry_type(mode: u32) -> EntryType {
             match mode as libc::mode_t & libc::S_IFMT {
                 libc::S_IFREG => EntryType::file(),
@@ -765,17 +764,6 @@ impl Header {
                 libc::S_IFBLK => EntryType::block_special(),
                 libc::S_IFDIR => EntryType::dir(),
                 libc::S_IFIFO => EntryType::fifo(),
-                _ => EntryType::new(b' '),
-            }
-        }
-
-        #[cfg(target_os = "redox")]
-        fn entry_type(mode: u32) -> EntryType {
-            use syscall;
-            match mode as u16 & syscall::MODE_TYPE {
-                syscall::MODE_FILE => EntryType::file(),
-                syscall::MODE_SYMLINK => EntryType::symlink(),
-                syscall::MODE_DIR => EntryType::dir(),
                 _ => EntryType::new(b' '),
             }
         }
@@ -1542,7 +1530,7 @@ fn ends_with_slash(p: &Path) -> bool {
     last == Some(b'/' as u16) || last == Some(b'\\' as u16)
 }
 
-#[cfg(any(unix, target_os = "redox"))]
+#[cfg(unix)]
 fn ends_with_slash(p: &Path) -> bool {
     p.as_os_str().as_bytes().ends_with(&[b'/'])
 }
@@ -1569,7 +1557,7 @@ pub fn path2bytes(p: &Path) -> io::Result<Cow<[u8]>> {
         })
 }
 
-#[cfg(any(unix, target_os = "redox"))]
+#[cfg(unix)]
 /// On unix this will never fail
 pub fn path2bytes(p: &Path) -> io::Result<Cow<[u8]>> {
     Ok(p.as_os_str().as_bytes()).map(Cow::Borrowed)
@@ -1598,7 +1586,7 @@ pub fn bytes2path(bytes: Cow<[u8]>) -> io::Result<Cow<Path>> {
     }
 }
 
-#[cfg(any(unix, target_os = "redox"))]
+#[cfg(unix)]
 /// On unix this operation can never fail.
 pub fn bytes2path(bytes: Cow<[u8]>) -> io::Result<Cow<Path>> {
     use std::ffi::{OsStr, OsString};


### PR DESCRIPTION
Redox is part of the unix target family now and supports all the libc functions used in tar-rs