### PR TITLE
Bump to 0.4.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tar"
-version = "0.4.27"
+version = "0.4.28"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 homepage = "https://github.com/alexcrichton/tar-rs"
 repository = "https://github.com/alexcrichton/tar-rs"


### PR DESCRIPTION
This ensures crates depending on tar-rs 0.4 and newer can build on Redox