### PR TITLE
Implement consistent, configurable overwriting behaviour for files and symlinks

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -22,6 +22,7 @@ pub struct ArchiveInner<R: ?Sized> {
     unpack_xattrs: bool,
     preserve_permissions: bool,
     preserve_mtime: bool,
+    overwrite: bool,
     ignore_zeros: bool,
     obj: RefCell<R>,
 }
@@ -47,6 +48,7 @@ impl<R: Read> Archive<R> {
                 unpack_xattrs: false,
                 preserve_permissions: false,
                 preserve_mtime: true,
+                overwrite: true,
                 ignore_zeros: false,
                 obj: RefCell::new(obj),
                 pos: Cell::new(0),
@@ -115,6 +117,11 @@ impl<R: Read> Archive<R> {
     /// Unix.
     pub fn set_preserve_permissions(&mut self, preserve: bool) {
         self.inner.preserve_permissions = preserve;
+    }
+
+    /// Indicate whether files and symlinks should be overwritten on extraction.
+    pub fn set_overwrite(&mut self, overwrite: bool) {
+        self.inner.overwrite = overwrite;
     }
 
     /// Indicate whether access time information is preserved when unpacking
@@ -255,6 +262,7 @@ impl<'a> EntriesFields<'a> {
             unpack_xattrs: self.archive.inner.unpack_xattrs,
             preserve_permissions: self.archive.inner.preserve_permissions,
             preserve_mtime: self.archive.inner.preserve_mtime,
+            overwrite: self.archive.inner.overwrite,
         };
 
         // Store where the next entry is, rounding up by 512 bytes (the size of

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -40,6 +40,7 @@ pub struct EntryFields<'a> {
     pub unpack_xattrs: bool,
     pub preserve_permissions: bool,
     pub preserve_mtime: bool,
+    pub overwrite: bool,
 }
 
 pub enum EntryIo<'a> {
@@ -484,17 +485,26 @@ impl<'a> EntryFields<'a> {
                     )
                 })?;
             } else {
-                symlink(&src, dst).map_err(|err| {
-                    Error::new(
-                        err.kind(),
-                        format!(
-                            "{} when symlinking {} to {}",
-                            err,
-                            src.display(),
-                            dst.display()
-                        ),
-                    )
-                })?;
+                symlink(&src, dst)
+                    .or_else(|err_io| {
+                        if err_io.kind() == io::ErrorKind::AlreadyExists && self.overwrite {
+                            // remove dest and try once more
+                            std::fs::remove_file(dst).and_then(|()| symlink(&src, dst))
+                        } else {
+                            Err(err_io)
+                        }
+                    })
+                    .map_err(|err| {
+                        Error::new(
+                            err.kind(),
+                            format!(
+                                "{} when symlinking {} to {}",
+                                err,
+                                src.display(),
+                                dst.display()
+                            ),
+                        )
+                    })?;
             };
             return Ok(Unpacked::__Nonexhaustive);
 
@@ -550,12 +560,14 @@ impl<'a> EntryFields<'a> {
             let mut f = open(dst).or_else(|err| {
                 if err.kind() != ErrorKind::AlreadyExists {
                     Err(err)
-                } else {
+                } else if self.overwrite {
                     match fs::remove_file(dst) {
                         Ok(()) => open(dst),
                         Err(ref e) if e.kind() == io::ErrorKind::NotFound => open(dst),
                         Err(e) => Err(e),
                     }
+                } else {
+                    Err(err)
                 }
             })?;
             for io in self.data.drain(..) {

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -282,7 +282,6 @@ fn extracting_duplicate_file_succeed() {
 fn extracting_duplicate_link_fail() {
     let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let path_present = td.path().join("lnk");
-
     t!(std::os::unix::fs::symlink("file", path_present));
 
     let rdr = Cursor::new(tar!("link.tar"));
@@ -306,7 +305,6 @@ fn extracting_duplicate_link_fail() {
 fn extracting_duplicate_link_succeed() {
     let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
     let path_present = td.path().join("lnk");
-
     t!(std::os::unix::fs::symlink("file", path_present));
 
     let rdr = Cursor::new(tar!("link.tar"));


### PR DESCRIPTION
Minor inconsistency, files were overwritten, symlinks were not. Now, this behaviour is consistent and configurable.

More specific PR in response to comments on #217

>> Would be nice to have an ability to overwrite symlinks.
>
> I agree. @moschroe thank you for implementing this! Would you be wiling to split that change to a separate PR? I'm hopeful that will increase the chances of merging this feature.
> 
> _Originally posted by @steveeJ in https://github.com/alexcrichton/tar-rs/pull/217#issuecomment-641192912_