### PR TITLE
cannonicalize unpack destination to safely handle long paths on windows

### DIFF
--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1019,3 +1019,16 @@ fn long_path() {
     let mut ar = Archive::new(rdr);
     assert!(ar.unpack(td.path()).is_ok());
 }
+
+#[test]
+fn unpack_path_larger_than_windows_max_path() {
+    let dir_name = "iamaprettylongnameandtobepreciseiam91characterslongwhichsomethinkisreallylongandothersdonot";
+    // 183 character directory name
+    let really_long_path = format!("{}{}", dir_name, dir_name);
+    let td = t!(TempBuilder::new().prefix(&really_long_path).tempdir());
+    // directory in 7z_long_path.tar is over 100 chars
+    let rdr = Cursor::new(tar!("7z_long_path.tar"));
+    let mut ar = Archive::new(rdr);
+    // should unpack path greater than windows MAX_PATH length of 260 characters
+    assert!(ar.unpack(td.path()).is_ok());
+}


### PR DESCRIPTION
This addresses a scenario on windows where files may be unpacked with a path over 260 (`MAX_PATH`) charachters. Such a case results in a `NotFound` error when creating the file. This cannonicalizes the unpack `dst` which will prepend `\\?\` to the path allowing Windows APIs to treat the path as an extended-length path supporting 32,767 characters.

I can understand if the author of this crate would prefer callers to cannonicalize the path themselves. However in the process of migrating from libarchive to this crate, this behavior was surprising since libarchive [performs the prepending](https://github.com/libarchive/libarchive/blob/3649ed23c6b4392d692580c03b10a611e3eaaa32/tar/bsdtar_windows.c#L61) of `\\?\` for the caller.

Signed-off-by: mwrock <matt@mattwrock.com>