### PR TITLE
Remove dead dependency on redox-syscall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,5 @@ tempfile = "3"
 xattr = { version = "0.2", optional = true }
 libc = "0.2"
 
-[target.'cfg(target_os = "redox")'.dependencies]
-redox_syscall = "0.1"
-
 [features]
 default = ["xattr"]

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -563,7 +563,7 @@ impl<'a> EntryFields<'a> {
         // is attackable; if an existing file is found unlink it.
         fn open(dst: &Path) -> io::Result<std::fs::File> {
             OpenOptions::new().write(true).create_new(true).open(dst)
-        };
+        }
         let mut f = (|| -> io::Result<std::fs::File> {
             let mut f = open(dst).or_else(|err| {
                 if err.kind() != ErrorKind::AlreadyExists {


### PR DESCRIPTION
Usage of the redox-syscall crate was removed in #225, but its entry in
Cargo.toml got left behind.