### PR TITLE
builder: add support for archiving special files on Unix

### DIFF
--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1213,8 +1213,9 @@ fn read_only_directory_containing_files() {
     assert!(ar.unpack(td.path()).is_ok());
 }
 
+// This test was marked linux only due to macOS CI can't handle `set_current_dir` correctly
 #[test]
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn tar_directory_containing_special_files() {
     use std::env;
     use std::ffi::CString;
@@ -1236,11 +1237,6 @@ fn tar_directory_containing_special_files() {
     // append_path has a different logic for processing files, so we need to test it as well
     t!(ar.append_path("fifo"));
     t!(ar.append_dir_all("special", td.path()));
-    // unfortunately, macOS CI can't handle `set_current_dir` correctly
-    if !cfg!(target_os = "linux") {
-        t!(ar.finish());
-        return;
-    }
     // unfortunately, block device file cannot be created by non-root users
     // as a substitute, just test the file that exists on most Unix systems
     t!(env::set_current_dir("/dev/"));

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1212,3 +1212,35 @@ fn read_only_directory_containing_files() {
     let mut ar = Archive::new(&contents[..]);
     assert!(ar.unpack(td.path()).is_ok());
 }
+
+#[test]
+#[cfg(unix)]
+fn tar_directory_containing_special_files() {
+    use std::env;
+    use std::ffi::CString;
+
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
+    let cdev = td.path().join("chr");
+    let fifo = td.path().join("fifo");
+
+    unsafe {
+        let cdev_path = t!(CString::new(cdev.to_str().unwrap()));
+        let ret = libc::mknod(cdev_path.as_ptr(), libc::S_IFCHR | 0o644, 0);
+        assert_eq!(ret, 0);
+        let fifo_path = t!(CString::new(fifo.to_str().unwrap()));
+        let ret = libc::mknod(fifo_path.as_ptr(), libc::S_IFIFO | 0o644, 0);
+        assert_eq!(ret, 0);
+    }
+
+    t!(env::set_current_dir(td.path()));
+    let mut ar = Builder::new(Vec::new());
+    // append_path has a different logic for processing files, so we need to test it as well
+    t!(ar.append_path("chr"));
+    t!(ar.append_path("fifo"));
+    t!(ar.append_dir_all("special", td.path()));
+    // unfortunately, block device file cannot be created by non-root users
+    // as a substitute, just test the file that exists on most Unix systems
+    t!(env::set_current_dir("/dev/"));
+    t!(ar.append_path("loop0"));
+    t!(ar.finish());
+}

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1236,6 +1236,11 @@ fn tar_directory_containing_special_files() {
     // append_path has a different logic for processing files, so we need to test it as well
     t!(ar.append_path("fifo"));
     t!(ar.append_dir_all("special", td.path()));
+    // unfortunately, macOS CI can't handle `set_current_dir` correctly
+    if !cfg!(target_os = "linux") {
+        t!(ar.finish());
+        return;
+    }
     // unfortunately, block device file cannot be created by non-root users
     // as a substitute, just test the file that exists on most Unix systems
     t!(env::set_current_dir("/dev/"));


### PR DESCRIPTION
Added support for archiving character, block and FIFO files on Unix, this is useful when you want to take a whole system backup or re-archiving an extracted system image.

The file handling in this pull request isn't particularly graceful since I am not very experienced with the codebase, any suggestions are welcome!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexcrichton/tar-rs/246)
<!-- Reviewable:end -->
