### PR TITLE
Avoid zero-mtime files

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -734,7 +734,16 @@ impl Header {
                 self.set_mode(meta.mode() as u32);
             }
             HeaderMode::Deterministic => {
-                self.set_mtime(0);
+                // We could in theory set the mtime to zero here, but not all
+                // tools seem to behave well when ingesting files with a 0
+                // timestamp. For example rust-lang/cargo#9512 shows that lldb
+                // doesn't ingest files with a zero timestamp correctly.
+                //
+                // We just need things to be deterministic here so just pick
+                // something that isn't zero. This time, chosen after careful
+                // deliberation, corresponds to Nov 29, 1973.
+                self.set_mtime(123456789);
+
                 self.set_uid(0);
                 self.set_gid(0);
 


### PR DESCRIPTION
With rust-lang/cargo#9512 discovered this is, uh, odd fallout of the
"deterministic" header mode in this crate. This is an unintended
consequence of the deterministic header mode which should ideally be
fixable. This commit changes the `tar` crate to use a different constant
than 0 when creating archives with the deterministic header mode
(specifically 123456789: Nov 29, 1973). It also will now refuse to
create files with a 0 mtime, instead resetting the mtime to 1 which
should help the mtime be nonzero so tools like lldb don't accidentally
think it's zero.