### PR TITLE
Restore create_dir_all method for directory creation

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -773,7 +773,7 @@ impl<'a> EntryFields<'a> {
             if let Some(parent) = ancestor.parent() {
                 self.validate_inside_dst(dst, parent)?;
             }
-            fs::create_dir(ancestor)?;
+            fs::create_dir_all(ancestor)?;
         }
         Ok(())
     }


### PR DESCRIPTION
https://github.com/alexcrichton/tar-rs/releases/tag/0.4.36 can be breaking for callers using `unpack_in()` to unpack to the same directory in parallel. If multiple threads race to create the same parent, the later ones will now error; #259 switches to `create_dir()`, which errors if a folder already exists.
With the new validation added in #259 , it seems reasonable to restore `create_dir_all()` for the actual creation. What do you think?