### PR TITLE
Use rust birthday for HeaderMode::Deterministic timestamp

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -741,8 +741,9 @@ impl Header {
                 //
                 // We just need things to be deterministic here so just pick
                 // something that isn't zero. This time, chosen after careful
-                // deliberation, corresponds to Nov 29, 1973.
-                self.set_mtime(123456789);
+                // deliberation, corresponds to Jul 23, 2006 -- the date of the
+                // first commit for what would become Rust.
+                self.set_mtime(1153704088);
 
                 self.set_uid(0);
                 self.set_gid(0);


### PR DESCRIPTION
As described in rust-lang/crates.io#3859, the current arbitrary timestamp of 123456789 leads to Debian packages being auto-rejected due to the old timestamp.  This happens for any timestamps before 1975.

Instead of 123456789, use another, more recent arbitrary timestamp -- the timestamp of the first commit for what would become Rust.

https://github.com/graydon/rust-prehistory/commit/b0fd440798ab3cfb05c60a1a1bd2894e1618479e