### PR TITLE
Add public constructor for PaxExtensions

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -13,7 +13,6 @@ use crate::archive::ArchiveInner;
 use crate::error::TarError;
 use crate::header::bytes2path;
 use crate::other;
-use crate::pax::pax_extensions;
 use crate::{Archive, Header, PaxExtensions};
 
 /// A read-only view into an entry of an archive.
@@ -300,7 +299,7 @@ impl<'a> EntryFields<'a> {
             }
             None => {
                 if let Some(ref pax) = self.pax_extensions {
-                    let pax = pax_extensions(pax)
+                    let pax = PaxExtensions::new(pax)
                         .filter_map(|f| f.ok())
                         .find(|f| f.key_bytes() == b"path")
                         .map(|f| f.value_bytes());
@@ -336,7 +335,7 @@ impl<'a> EntryFields<'a> {
             }
             None => {
                 if let Some(ref pax) = self.pax_extensions {
-                    let pax = pax_extensions(pax)
+                    let pax = PaxExtensions::new(pax)
                         .filter_map(|f| f.ok())
                         .find(|f| f.key_bytes() == b"linkpath")
                         .map(|f| f.value_bytes());
@@ -358,7 +357,9 @@ impl<'a> EntryFields<'a> {
             }
             self.pax_extensions = Some(self.read_all()?);
         }
-        Ok(Some(pax_extensions(self.pax_extensions.as_ref().unwrap())))
+        Ok(Some(PaxExtensions::new(
+            self.pax_extensions.as_ref().unwrap(),
+        )))
     }
 
     fn unpack_in(&mut self, dst: &Path) -> io::Result<bool> {

--- a/src/pax.rs
+++ b/src/pax.rs
@@ -12,23 +12,26 @@ pub struct PaxExtensions<'entry> {
     data: slice::Split<'entry, u8, fn(&u8) -> bool>,
 }
 
+impl<'entry> PaxExtensions<'entry> {
+    /// Create new pax extensions iterator from the given entry data.
+    pub fn new(a: &'entry [u8]) -> Self {
+        fn is_newline(a: &u8) -> bool {
+            *a == b'\n'
+        }
+        PaxExtensions {
+            data: a.split(is_newline),
+        }
+    }
+}
+
 /// A key/value pair corresponding to a pax extension.
 pub struct PaxExtension<'entry> {
     key: &'entry [u8],
     value: &'entry [u8],
 }
 
-pub fn pax_extensions(a: &[u8]) -> PaxExtensions {
-    fn is_newline(a: &u8) -> bool {
-        *a == b'\n'
-    }
-    PaxExtensions {
-        data: a.split(is_newline),
-    }
-}
-
 pub fn pax_extensions_size(a: &[u8]) -> Option<u64> {
-    for extension in pax_extensions(a) {
+    for extension in PaxExtensions::new(a) {
         let current_extension = match extension {
             Ok(ext) => ext,
             Err(_) => return None,


### PR DESCRIPTION
I need to parse pax extensions without reading them from an `Archive`, but I can't find a way to create a `PaxExtensions` iterator without an `Entry`. I think the implementation of `PaxExtensions` is already fairly constrained by the public interface, so I don't think exposing the constructor should cause any issues?