### PR TITLE
Add an `append_link()` method to handle long link targets

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -420,6 +420,8 @@ impl Header {
     /// in the appropriate format. May fail if the link name is too long or if
     /// the path specified is not Unicode and this is a Windows platform. Will
     /// strip out any "." path component, which signifies the current directory.
+    ///
+    /// To use GNU long link names, prefer instead [`crate::Builder::append_link`].
     pub fn set_link_name<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
         self._set_link_name(p.as_ref())
     }


### PR DESCRIPTION
We should support appending long symlink targets, because this
occurs in real world filesystems.  In my case, RPM set up
`.build-id` symlinks which can get long.

Add an `append_link()` method following the precendent of
`append_path()` - we're just supporting *two* potentially
long filenames.

As a side benefit, we can just do the `std::io::empty()` dance
internally and not require the caller to specify it.

The addition of special case `append()` methods is unfortunate,
because the header API methods are then really an attractive nuisance.
We should potentially consider deprecating them.

Closes: #192