### PR TITLE
feat: unpack_with_filter(); append_dir_with_filter()

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -339,8 +339,8 @@ impl<W: Write> Builder<W> {
     ///
     /// let mut ar = Builder::new(Vec::new());
     ///
-    /// // Use the directory at one location, but insert it into the archive
-    /// // with a different name.
+    /// // Add an entry for the current directory (`.`), but insert it into the
+    /// // archive as `bardir`.
     /// ar.append_dir("bardir", ".").unwrap();
     /// ```
     pub fn append_dir<P, Q>(&mut self, path: P, src_path: Q) -> io::Result<()>
@@ -370,8 +370,8 @@ impl<W: Write> Builder<W> {
     ///
     /// let mut ar = Builder::new(Vec::new());
     ///
-    /// // Use the directory at one location, but insert it into the archive
-    /// // with a different name.
+    /// // Add the contents of the current directory (`.`), but insert it into
+    /// // the archive as `bardir`.
     /// ar.append_dir_all("bardir", ".").unwrap();
     /// ```
     pub fn append_dir_all<P, Q>(&mut self, path: P, src_path: Q) -> io::Result<()>


### PR DESCRIPTION
This seems related to https://github.com/alexcrichton/tar-rs/issues/279

in https://github.com/cargo-quick/cargo-quick/issues/14 I find myself wanting to create something similar to Docker layers, using the `tar` crate.

I want to be able to keep track of a list of all files that I unpacked, then do my `cargo build` and then unpack only the files that are new or have changed (I'm assuming that I won't have any deleted files, but if I do, the OCI spec has a way of encoding tombstones in layers, so I can copy that).

In theory, I could take control of the directory walking myself (that's what we do in https://github.com/cargo-quick/kache/blob/main/src/tar.rs) but when I started prototyping cargo-quickbuild, I used `append_dir_all()` and `.unpack()`, 

unresolved questions:
- [ ] there is an asymmetry between the filter for `unpack_with_filter()` and the one for `append_dir_with_filter()`. Should they be reconciled?
- [ ] is it okay that I don't add support for filtering directories at all? Can anyone think of a good api for this?
- [ ] there is an unwrap in the example for `unpack_with_filter()`. Should I make the callback fn return Result<bool> or something?
- [ ] the filter for `append_dir_with_filter()` currently just gives you `path`. I probably also want to know the mtime, to identify files that have changed. I wonder whether there is a point at which the `tar` crate has mtime in its hands but hasn't read the file from disk yet. If so, I could add the filter in there instead.
- [ ] should I be using `filter: impl FnMut(...)` for my function arguments, or does our minimum supported rust version policy forbid this?

If this feature adds too much complexity that you would rather not carry, please close it, and I will take control of the file walking myself in `cargo-quickbuild` instead.