### PR TITLE
Do not error on _set_perms(path) on Wasm32

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -824,7 +824,7 @@ impl<'a> EntryFields<'a> {
             mode: u32,
             _preserve: bool,
         ) -> io::Result<()> {
-            Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
+            Ok(())
         }
 
         #[cfg(all(unix, feature = "xattr"))]


### PR DESCRIPTION
Since Wasm32 does not yet have support for file permissions it is better to silently ignore them rather than to fail, since the rest of the library can still work on `wasm32`.