### PR TITLE
Make methods working with filesystem optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ writers. Additionally, great lengths are taken to ensure that the entire
 contents are never required to be entirely resident in memory all at once.
 """
 
+
 [dependencies]
-filetime = "0.2.8"
+filetime = { version = "0.2.8", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
@@ -30,3 +31,4 @@ libc = "0.2"
 
 [features]
 default = ["xattr"]
+fs = ["filetime"]

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -103,6 +103,7 @@ impl<R: Read> Archive<R> {
     /// let mut ar = Archive::new(File::open("foo.tar").unwrap());
     /// ar.unpack("foo").unwrap();
     /// ```
+    #[cfg(feature = "fs")]
     pub fn unpack<P: AsRef<Path>>(&mut self, dst: P) -> io::Result<()> {
         let me: &mut Archive<dyn Read> = self;
         me._unpack(dst.as_ref())
@@ -197,6 +198,7 @@ impl Archive<dyn Read + '_> {
         })
     }
 
+    #[cfg(feature = "fs")]
     fn _unpack(&mut self, dst: &Path) -> io::Result<()> {
         if dst.symlink_metadata().is_err() {
             fs::create_dir_all(&dst)

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -7,6 +7,7 @@ use std::io::{self, Error, ErrorKind, SeekFrom};
 use std::marker;
 use std::path::{Component, Path, PathBuf};
 
+#[cfg(feature = "fs")]
 use filetime::{self, FileTime};
 
 use crate::archive::ArchiveInner;
@@ -199,6 +200,7 @@ impl<'a, R: Read> Entry<'a, R> {
     ///     file.unpack(format!("file-{}", i)).unwrap();
     /// }
     /// ```
+    #[cfg(feature = "fs")]
     pub fn unpack<P: AsRef<Path>>(&mut self, dst: P) -> io::Result<Unpacked> {
         self.fields.unpack(None, dst.as_ref())
     }
@@ -227,6 +229,7 @@ impl<'a, R: Read> Entry<'a, R> {
     ///     file.unpack_in("target").unwrap();
     /// }
     /// ```
+    #[cfg(feature = "fs")]
     pub fn unpack_in<P: AsRef<Path>>(&mut self, dst: P) -> io::Result<bool> {
         self.fields.unpack_in(dst.as_ref())
     }
@@ -363,6 +366,7 @@ impl<'a> EntryFields<'a> {
         )))
     }
 
+    #[cfg(feature = "fs")]
     fn unpack_in(&mut self, dst: &Path) -> io::Result<bool> {
         // Notes regarding bsdtar 2.8.3 / libarchive 2.8.3:
         // * Leading '/'s are trimmed. For example, `///test` is treated as
@@ -443,6 +447,7 @@ impl<'a> EntryFields<'a> {
         })
     }
 
+    #[cfg(feature = "fs")]
     /// Returns access to the header of this entry in the archive.
     fn unpack(&mut self, target_base: Option<&Path>, dst: &Path) -> io::Result<Unpacked> {
         fn set_perms_ownerships(


### PR DESCRIPTION
I'm using this library on embedded project (esp-idf), and the provided stdlib does not export methods expected by the filetime library. 

This PR makes methods working directly with the filesystem optional