### PR TITLE
tests: Don't assume /dev/loop0 exists

### DIFF
--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1341,10 +1341,7 @@ fn tar_directory_containing_special_files() {
     // append_path has a different logic for processing files, so we need to test it as well
     t!(ar.append_path("fifo"));
     t!(ar.append_dir_all("special", td.path()));
-    // unfortunately, block device file cannot be created by non-root users
-    // as a substitute, just test the file that exists on most Unix systems
     t!(env::set_current_dir("/dev/"));
-    t!(ar.append_path("loop0"));
     // CI systems seem to have issues with creating a chr device
     t!(ar.append_path("null"));
     t!(ar.finish());


### PR DESCRIPTION
It doesn't by default on e.g. current Fedora and RHEL systems. I suspect most people so far have been running this on Ubuntu which uses snaps which use loopback devices, but we can't rely on that.

For test coverage here, ultimately there's not really a good block device to rely on without going through a lot of special casing.

Let's just test character devices.