### PR TITLE
entry: Use `strip_prefix`

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -841,11 +841,7 @@ impl<'a> EntryFields<'a> {
                 .filter_map(|e| {
                     let key = e.key_bytes();
                     let prefix = b"SCHILY.xattr.";
-                    if key.starts_with(prefix) {
-                        Some((&key[prefix.len()..], e))
-                    } else {
-                        None
-                    }
+                    key.strip_prefix(prefix).map(|rest| (rest, e))
                 })
                 .map(|(key, e)| (OsStr::from_bytes(key), e.value_bytes()));
 


### PR DESCRIPTION
Minor drive by code cleanup; `strip_prefix` is just more readable and more bug-resistant than manually doing it with `starts_with` combined with slicing.