### PR TITLE
Update xattr requirement from 0.2 to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ filetime = "0.2.8"
 tempfile = "3"
 
 [target."cfg(unix)".dependencies]
-xattr = { version = "0.2", optional = true }
+xattr = { version = "1.0", optional = true }
 libc = "0.2"
 
 [features]


### PR DESCRIPTION
Same content as #307; trying to get CI to re-run to capture error messages.