### PR TITLE
Add a force_mtime() function to allow overriding all mtime fields

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -279,14 +279,14 @@ impl Header {
     /// This is useful for initializing a `Header` from the OS's metadata from a
     /// file. By default, this will use `HeaderMode::Complete` to include all
     /// metadata.
-    pub fn set_metadata(&mut self, meta: &fs::Metadata) {
-        self.fill_from(meta, HeaderMode::Complete);
+    pub fn set_metadata(&mut self, meta: &fs::Metadata, force_mtime: Option<u64>) {
+        self.fill_from(meta, HeaderMode::Complete, force_mtime);
     }
 
     /// Sets only the metadata relevant to the given HeaderMode in this header
     /// from the metadata argument provided.
-    pub fn set_metadata_in_mode(&mut self, meta: &fs::Metadata, mode: HeaderMode) {
-        self.fill_from(meta, mode);
+    pub fn set_metadata_in_mode(&mut self, meta: &fs::Metadata, mode: HeaderMode, force_mtime: Option<u64>) {
+        self.fill_from(meta, mode, force_mtime);
     }
 
     /// Returns the size of entry's data this header represents.
@@ -714,8 +714,8 @@ impl Header {
             .fold(0, |a, b| a + (*b as u32))
     }
 
-    fn fill_from(&mut self, meta: &fs::Metadata, mode: HeaderMode) {
-        self.fill_platform_from(meta, mode);
+    fn fill_from(&mut self, meta: &fs::Metadata, mode: HeaderMode, force_mtime: Option<u64>) {
+        self.fill_platform_from(meta, mode, force_mtime);
         // Set size of directories to zero
         self.set_size(if meta.is_dir() || meta.file_type().is_symlink() {
             0
@@ -739,10 +739,15 @@ impl Header {
     }
 
     #[cfg(unix)]
-    fn fill_platform_from(&mut self, meta: &fs::Metadata, mode: HeaderMode) {
+    fn fill_platform_from(
+        &mut self,
+        meta: &fs::Metadata,
+        mode: HeaderMode,
+        force_mtime: Option<u64>,
+    ) {
         match mode {
             HeaderMode::Complete => {
-                self.set_mtime(meta.mtime() as u64);
+                self.set_mtime(force_mtime.unwrap_or(meta.mtime() as u64));
                 self.set_uid(meta.uid() as u64);
                 self.set_gid(meta.gid() as u64);
                 self.set_mode(meta.mode() as u32);

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -164,7 +164,7 @@ fn large_filename() {
     let filename = repeat("abcd/").take(50).collect::<String>();
     let mut header = Header::new_ustar();
     header.set_path(&filename).unwrap();
-    header.set_metadata(&t!(fs::metadata(&path)));
+    header.set_metadata(&t!(fs::metadata(&path)), None);
     header.set_cksum();
     t!(ar.append(&header, &b"test"[..]));
     let too_long = repeat("abcd").take(200).collect::<String>();
@@ -541,7 +541,7 @@ fn handling_incorrect_file_size() {
     let mut file = t!(File::open(&path));
     let mut header = Header::new_old();
     t!(header.set_path("somepath"));
-    header.set_metadata(&t!(file.metadata()));
+    header.set_metadata(&t!(file.metadata()), None);
     header.set_size(2048); // past the end of file null blocks
     header.set_cksum();
     t!(ar.append(&header, &mut file));
@@ -751,7 +751,7 @@ fn backslash_treated_well() {
     // Unpack an archive with a backslash in the name
     let mut ar = Builder::new(Vec::<u8>::new());
     let mut header = Header::new_gnu();
-    header.set_metadata(&t!(fs::metadata(td.path())));
+    header.set_metadata(&t!(fs::metadata(td.path())), None);
     header.set_size(0);
     for (a, b) in header.as_old_mut().name.iter_mut().zip(b"foo\\bar\x00") {
         *a = *b;

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -188,7 +188,7 @@ fn set_metadata_deterministic() {
         perms.set_readonly(readonly);
         t!(fs::set_permissions(path, perms));
         let mut h = Header::new_ustar();
-        h.set_metadata_in_mode(&t!(path.metadata()), HeaderMode::Deterministic);
+        h.set_metadata_in_mode(&t!(path.metadata()), HeaderMode::Deterministic, None);
         Ok(h)
     }
 


### PR DESCRIPTION
Hi Alex,

Thanks for the excellent tar crate. While developing a project, we needed a way to override the mtime. This was the most direct route to get it done, even though I'm rather sure it isn't something you'd want to merge upstream.

So, here is some code we wrote. We're sending the PR for you to look at and consider as a use case. We'd be interested in hearing back from you if you're interested in a better implementation, and if so what you think that might look like.

Thank you!