### PR TITLE
update xattr to 1.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ filetime = "0.2.8"
 tempfile = "3"
 
 [target."cfg(unix)".dependencies]
-xattr = { version = "1.0", optional = true }
+xattr = { version = "1.1.3", optional = true }
 libc = "0.2"
 
 [features]


### PR DESCRIPTION
xattr 1.0.0 through 1.1.2 have a bug
(https://github.com/Stebalien/xattr/pull/48). Bump the requirement so that downstream dependents get the latest version.