### PR TITLE
Release 0.4.41

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tar"
-version = "0.4.40"
+version = "0.4.41"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 homepage = "https://github.com/alexcrichton/tar-rs"
 repository = "https://github.com/alexcrichton/tar-rs"


### PR DESCRIPTION
There's only one notable change here, which is that `Header::Deterministic` on Windows now uses the same timestamp as is used on Unix.  If this breaks your use case, please let us know in https://github.com/alexcrichton/tar-rs/pull/346

Besides that, there's a few testing, documentation, and internal cleanups.  We're hoping to continue to merge PRs and address issues; this release is small but is intending to maintain momentum.