### PR TITLE
Remove unused `use` in doctest

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -365,7 +365,6 @@ impl<W: Write> Builder<W> {
     /// # Examples
     ///
     /// ```
-    /// use std::fs;
     /// use tar::Builder;
     ///
     /// let mut ar = Builder::new(Vec::new());


### PR DESCRIPTION
The `use std::fs` in the for `append_dir_all` tests is not used. We can simplify this example by removing it.