### PR TITLE
Update append_dir_all doc test

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -360,7 +360,8 @@ impl<W: Write> Builder<W> {
     /// operation then this may corrupt the archive.
     ///
     /// Also note that after all files have been written to an archive the
-    /// `finish` function needs to be called to finish writing the archive.
+    /// `finish` or `into_inner` function needs to be called to finish
+    /// writing the archive.
     ///
     /// # Examples
     ///
@@ -370,9 +371,10 @@ impl<W: Write> Builder<W> {
     ///
     /// let mut ar = Builder::new(Vec::new());
     ///
-    /// // Use the directory at one location, but insert it into the archive
-    /// // with a different name.
+    /// // Use the directory at one location ("."), but insert it into the archive
+    /// // with a different name ("bardir").
     /// ar.append_dir_all("bardir", ".").unwrap();
+    /// ar.finish().unwrap();
     /// ```
     pub fn append_dir_all<P, Q>(&mut self, path: P, src_path: Q) -> io::Result<()>
     where


### PR DESCRIPTION
## Call `finish`

The text of `append_dir_all` suggests that `finish` must always be called. This commit updates the example to call `finish`.

## Link to `into_inner`

Further, the docs for `finish` suggest that `into_inner` is an alternate (and possibly preferred), so I added a link to that function.

> /// In most situations the `into_inner` method should be preferred.
>     pub fn finish(&mut self) -> io::Result<()> {

## Label which directory is which in the comment

Lastly, I needed clarification about which directory was renamed in the example. Without prior knowledge, it could be that a directory named "bardir" is being renamed to the current dir or that the current dir is being inserted as a "bardir." The input args are `path` and `src_path`, which provides a little clue. 

To make the example more explicit, I added that information to the comment.