### PR TITLE
Add append_dir_all doc test without renaming

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -374,6 +374,35 @@ impl<W: Write> Builder<W> {
     /// // with a different name.
     /// ar.append_dir_all("bardir", ".").unwrap();
     /// ```
+    ///
+    /// Use `append_dir_all` with an empty string as the first path argument to
+    /// create an archive from all files in a directory without renaming.
+    ///
+    /// ```
+    /// use std::fs;
+    /// use std::path::PathBuf;
+    /// use tar::{Archive, Builder};
+    ///
+    /// let tmpdir = tempfile::tempdir().unwrap();
+    /// let path = tmpdir.path();
+    /// fs::write(path.join("a.txt"), b"hello").unwrap();
+    /// fs::write(path.join("b.txt"), b"world").unwrap();
+    ///
+    /// // Create a tarball from the files in the directory
+    /// let mut ar = Builder::new(Vec::new());
+    /// ar.append_dir_all("", path).unwrap();
+    ///
+    /// // List files in the archive
+    /// let archive = ar.into_inner().unwrap();
+    /// let archived_files = Archive::new(archive.as_slice())
+    ///     .entries()
+    ///     .unwrap()
+    ///     .map(|entry| entry.unwrap().path().unwrap().into_owned())
+    ///     .collect::<Vec<_>>();
+    ///
+    /// assert!(archived_files.contains(&PathBuf::from("a.txt")));
+    /// assert!(archived_files.contains(&PathBuf::from("b.txt")));
+    /// ```
     pub fn append_dir_all<P, Q>(&mut self, path: P, src_path: Q) -> io::Result<()>
     where
         P: AsRef<Path>,


### PR DESCRIPTION
This adds a doc test that shows how to add the contents of a directory to an archive without renaming them.

## Context

It might seem silly, but I was unsure of the correct way to write all the contents of a directory to an archive without renaming. I initially looked for a different associated function that only took one argument but couldn't find one. When that failed, I guessed and checked that `"."` would work, and it did. On searching, others used `""`. 

It makes sense in hind-site, but I would have loved to have a signal that this was the correct way to perform that operation.

In addition to demonstrating `append_dir_all("", ...` this example also shows usage of `into_inner` to retrieve a reference to the original struct. Which is the recommended alternative to `finish`.

I certainly understand that you can't have an example for every permutation and combination, but I believe that archiving the contents of a directory without renaming is common-enough to warrant an explicit example.