### PR TITLE
[Symlink] Add symlink ownership management.

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -576,6 +576,12 @@ impl<'a> EntryFields<'a> {
                             ),
                         )
                     })?;
+                // While permissions on symlinks are meaningless on most systems, the ownership
+                // of symlinks is important as it dictates the access control to the symlink
+                // itself.
+                if self.preserve_ownerships {
+                    set_ownerships(dst, &None, self.header.uid()?, self.header.gid()?)?;
+                }
                 if self.preserve_mtime {
                     if let Some(mtime) = get_mtime(&self.header) {
                         filetime::set_symlink_file_times(dst, mtime, mtime).map_err(|e| {


### PR DESCRIPTION
## Context 

The `tar-rs` crate ignores ownership of symlinks, even if `.set_preserve_ownerships(true);` is invoked. While permissions of symlinks are mostly meaningless on most systems, ownership does dictate the access to symlinks. For instance:

```
$ mkdir foo 
$ sudo ln -s foo link
$  rm link
rm: link: Permission denied
```

## This PR

In this PR I add the right invocation for symlink ownership change and expand the tests to include directories and symlinks.