### PR TITLE
Ensure directory permissions are correctly applied.

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -238,6 +238,15 @@ impl Archive<dyn Read + '_> {
                 file.unpack_in(dst)?;
             }
         }
+
+        // Apply the directories.
+        //
+        // Note: the order of application is important to permissions. That is, we must traverse
+        // the filesystem graph in topological ordering or else we risk not being able to create
+        // child directories within those of more restrictive permissions. See [0] for details.
+        //
+        // [0]: <https://github.com/alexcrichton/tar-rs/issues/242>
+        directories.sort_by(|a, b| b.path_bytes().cmp(&a.path_bytes()));
         for mut dir in directories {
             dir.unpack_in(dst)?;
         }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -576,6 +576,12 @@ impl<'a> EntryFields<'a> {
                             ),
                         )
                     })?;
+                // While permissions on symlinks are meaningless on most systems, the ownership
+                // of symlinks is important as it dictates the access control to the symlink
+                // itself.
+                if self.preserve_ownerships {
+                    set_ownerships(dst, &None, self.header.uid()?, self.header.gid()?)?;
+                }
                 if self.preserve_mtime {
                     if let Some(mtime) = get_mtime(&self.header) {
                         filetime::set_symlink_file_times(dst, mtime, mtime).map_err(|e| {


### PR DESCRIPTION
The current implementation will fail on directory structures which have parent directories less permissive than child directories. For instance, any structure of the sort:

```
- root_dir (0o555)
  - child_dir (0o755)
```

Will fail to be created since `root_dir` permissions won't allow `child_dir` to be created. The simple fix here is to reorder the directories and treat the filesystem as a tree processed in topological order. This PR does just that.