### PR TITLE
fix: Don't forget to zero-terminate in octal_into

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::fs;
 use std::io;
 use std::iter;
-use std::iter::repeat;
+use std::iter::{once, repeat};
 use std::mem;
 use std::path::{Component, Path, PathBuf};
 use std::str;
@@ -1413,8 +1413,8 @@ fn octal_from(slice: &[u8]) -> io::Result<u64> {
 
 fn octal_into<T: fmt::Octal>(dst: &mut [u8], val: T) {
     let o = format!("{:o}", val);
-    let value = o.bytes().rev().chain(repeat(b'0'));
-    for (slot, value) in dst.iter_mut().rev().skip(1).zip(value) {
+    let value = once(b'\0').chain(o.bytes().rev().chain(repeat(b'0')));
+    for (slot, value) in dst.iter_mut().rev().zip(value) {
         *slot = value;
     }
 }

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -218,6 +218,8 @@ fn extended_numeric_format() {
     assert_eq!(h.size, [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 50, 0]);
     h.as_header_mut().set_size(8589934593);
     assert_eq!(h.size, [0x80, 0, 0, 0, 0, 0, 0, 0x02, 0, 0, 0, 1]);
+    h.as_header_mut().set_size(44);
+    assert_eq!(h.size, [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 52, 0]);
     h.size = [0x80, 0, 0, 0, 0, 0, 0, 0x02, 0, 0, 0, 0];
     assert_eq!(h.as_header().entry_size().unwrap(), 0x0200000000);
     h.size = [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 51, 0];


### PR DESCRIPTION
Usually, numeric fields like `size` are set only once, implicitly assuming that the previous data is zero-initialized.  However, it's not always the case, particularly when overriding large values written in the extended form.