### PR TITLE
feat: Support adding sparse files to archives

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,7 +4,9 @@ use std::io::prelude::*;
 use std::path::Path;
 use std::str;
 
+use crate::header::GNU_SPARSE_HEADERS_COUNT;
 use crate::header::{path2bytes, HeaderMode};
+use crate::GnuExtSparseHeader;
 use crate::{other, EntryType, Header};
 
 /// A structure for building archives
@@ -21,6 +23,7 @@ pub struct Builder<W: Write> {
 struct BuilderOptions {
     mode: HeaderMode,
     follow: bool,
+    sparse: bool,
 }
 
 impl<W: Write> Builder<W> {
@@ -32,6 +35,7 @@ impl<W: Write> Builder<W> {
             options: BuilderOptions {
                 mode: HeaderMode::Complete,
                 follow: true,
+                sparse: true,
             },
             finished: false,
             obj: Some(obj),
@@ -52,6 +56,13 @@ impl<W: Write> Builder<W> {
     /// `--dereference` or `-h` options <https://man7.org/linux/man-pages/man1/tar.1.html>.
     pub fn follow_symlinks(&mut self, follow: bool) {
         self.options.follow = follow;
+    }
+
+    /// Handle sparse files efficiently, if supported by the underlying
+    /// filesystem. When true, sparse file information is read from disk and
+    /// empty segments are omitted from the archive. Defaults to true.
+    pub fn sparse(&mut self, sparse: bool) {
+        self.options.sparse = sparse;
     }
 
     /// Gets shared reference to the underlying object.
@@ -435,14 +446,16 @@ impl<W: Write> Builder<W> {
 fn append(mut dst: &mut dyn Write, header: &Header, mut data: &mut dyn Read) -> io::Result<()> {
     dst.write_all(header.as_bytes())?;
     let len = io::copy(&mut data, &mut dst)?;
+    pad_zeroes(&mut dst, len)?;
+    Ok(())
+}
 
-    // Pad with zeros if necessary.
+fn pad_zeroes(dst: &mut dyn Write, len: u64) -> io::Result<()> {
     let buf = [0; 512];
     let remaining = 512 - (len % 512);
     if remaining < 512 {
         dst.write_all(&buf[..remaining as usize])?;
     }
-
     Ok(())
 }
 
@@ -469,26 +482,12 @@ fn append_path_with_name(
     };
     let ar_name = name.unwrap_or(path);
     if stat.is_file() {
-        append_fs(
-            dst,
-            ar_name,
-            &stat,
-            &mut fs::File::open(path)?,
-            options.mode,
-            None,
-        )
+        append_file(dst, ar_name, &mut fs::File::open(path)?, options)
     } else if stat.is_dir() {
-        append_fs(dst, ar_name, &stat, &mut io::empty(), options.mode, None)
+        append_fs(dst, ar_name, &stat, options.mode, None)
     } else if stat.file_type().is_symlink() {
         let link_name = fs::read_link(path)?;
-        append_fs(
-            dst,
-            ar_name,
-            &stat,
-            &mut io::empty(),
-            options.mode,
-            Some(&link_name),
-        )
+        append_fs(dst, ar_name, &stat, options.mode, Some(&link_name))
     } else {
         #[cfg(unix)]
         {
@@ -552,7 +551,31 @@ fn append_file(
     options: BuilderOptions,
 ) -> io::Result<()> {
     let stat = file.metadata()?;
-    append_fs(dst, path, &stat, file, options.mode, None)
+    let mut header = Header::new_gnu();
+
+    prepare_header_path(dst, &mut header, path)?;
+    header.set_metadata_in_mode(&stat, options.mode);
+    let sparse_entries = if options.sparse {
+        prepare_header_sparse(file, &stat, &mut header)?
+    } else {
+        None
+    };
+    header.set_cksum();
+    dst.write_all(header.as_bytes())?;
+
+    if let Some(sparse_entries) = sparse_entries {
+        append_extended_sparse_headers(dst, &sparse_entries)?;
+        for entry in sparse_entries.entries {
+            file.seek(io::SeekFrom::Start(entry.offset))?;
+            io::copy(&mut file.take(entry.num_bytes), dst)?;
+        }
+        pad_zeroes(dst, sparse_entries.on_disk_size)?;
+    } else {
+        let len = io::copy(file, dst)?;
+        pad_zeroes(dst, len)?;
+    }
+
+    Ok(())
 }
 
 fn append_dir(
@@ -562,7 +585,7 @@ fn append_dir(
     options: BuilderOptions,
 ) -> io::Result<()> {
     let stat = fs::metadata(src_path)?;
-    append_fs(dst, path, &stat, &mut io::empty(), options.mode, None)
+    append_fs(dst, path, &stat, options.mode, None)
 }
 
 fn prepare_header(size: u64, entry_type: u8) -> Header {
@@ -630,11 +653,67 @@ fn prepare_header_link(
     Ok(())
 }
 
+fn prepare_header_sparse(
+    file: &mut fs::File,
+    stat: &fs::Metadata,
+    header: &mut Header,
+) -> io::Result<Option<SparseEntries>> {
+    let entries = match find_sparse_entries(file, stat)? {
+        Some(entries) => entries,
+        _ => return Ok(None),
+    };
+
+    header.set_entry_type(EntryType::GNUSparse);
+    header.set_size(entries.on_disk_size);
+
+    // Write the first 4 (GNU_SPARSE_HEADERS_COUNT) entries to the given header.
+    // The remaining entries will be written as subsequent extended headers. See
+    // https://www.gnu.org/software/tar/manual/html_section/Sparse-Formats.html#Old-GNU-Format
+    // for details on the format.
+    let gnu_header = &mut header.as_gnu_mut().unwrap();
+    gnu_header.set_real_size(entries.size());
+
+    for (entry, header_entry) in std::iter::zip(&entries.entries, &mut gnu_header.sparse) {
+        header_entry.set_offset(entry.offset);
+        header_entry.set_length(entry.num_bytes);
+    }
+    gnu_header.set_is_extended(entries.entries.len() > gnu_header.sparse.len());
+
+    Ok(Some(entries))
+}
+
+/// Write extra sparse headers into `dst` for those entries that did not fit in the main header.
+fn append_extended_sparse_headers(dst: &mut dyn Write, entries: &SparseEntries) -> io::Result<()> {
+    // The first `GNU_SPARSE_HEADERS_COUNT` entries are written to the main header, so skip them.
+    let mut it = entries
+        .entries
+        .iter()
+        .skip(GNU_SPARSE_HEADERS_COUNT)
+        .peekable();
+
+    // Each GnuExtSparseHeader can hold up to fixed number of sparse entries (21).
+    // So we pack entries into multiple headers if necessary.
+    while it.peek().is_some() {
+        let mut ext_header = GnuExtSparseHeader::new();
+        for header_entry in ext_header.sparse.iter_mut() {
+            if let Some(entry) = it.next() {
+                header_entry.set_offset(entry.offset);
+                header_entry.set_length(entry.num_bytes);
+            } else {
+                break;
+            }
+        }
+        ext_header.set_is_extended(it.peek().is_some());
+        dst.write_all(ext_header.as_bytes())?;
+    }
+
+    Ok(())
+}
+
 fn append_fs(
     dst: &mut dyn Write,
     path: &Path,
     meta: &fs::Metadata,
-    read: &mut dyn Read,
     mode: HeaderMode,
     link_name: Option<&Path>,
 ) -> io::Result<()> {
@@ -646,7 +725,7 @@ fn append_fs(
         prepare_header_link(dst, &mut header, link_name)?;
     }
     header.set_cksum();
-    append(dst, &header, read)
+    dst.write_all(header.as_bytes())
 }
 
 fn append_dir_all(
@@ -671,14 +750,7 @@ fn append_dir_all(
         } else if !options.follow && is_symlink {
             let stat = fs::symlink_metadata(&src)?;
             let link_name = fs::read_link(&src)?;
-            append_fs(
-                dst,
-                &dest,
-                &stat,
-                &mut io::empty(),
-                options.mode,
-                Some(&link_name),
-            )?;
+            append_fs(dst, &dest, &stat, options.mode, Some(&link_name))?;
         } else {
             #[cfg(unix)]
             {
@@ -694,8 +766,414 @@ fn append_dir_all(
     Ok(())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SparseEntries {
+    entries: Vec<SparseEntry>,
+    on_disk_size: u64,
+}
+
+impl SparseEntries {
+    fn size(&self) -> u64 {
+        self.entries.last().map_or(0, |e| e.offset + e.num_bytes)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct SparseEntry {
+    offset: u64,
+    num_bytes: u64,
+}
+
+/// Find sparse entries in a file. Returns:
+/// * `Ok(Some(_))` if the file is sparse.
+/// * `Ok(None)` if the file is not sparse, or if the file system does not
+///    support sparse files.
+/// * `Err(_)` if an error occurred. The lack of support for sparse files is not
+///    considered an error. It might return an error if the file is modified
+///    while reading.
+fn find_sparse_entries(
+    file: &mut fs::File,
+    stat: &fs::Metadata,
+) -> io::Result<Option<SparseEntries>> {
+    #[cfg(not(any(target_os = "android", target_os = "freebsd", target_os = "linux")))]
+    {
+        let _ = file;
+        let _ = stat;
+        Ok(None)
+    }
+
+    #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
+    find_sparse_entries_seek(file, stat)
+}
+
+/// Implementation of `find_sparse_entries` using `SEEK_HOLE` and `SEEK_DATA`.
+#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
+fn find_sparse_entries_seek(
+    file: &mut fs::File,
+    stat: &fs::Metadata,
+) -> io::Result<Option<SparseEntries>> {
+    use std::os::unix::fs::MetadataExt as _;
+    use std::os::unix::io::AsRawFd as _;
+
+    fn lseek(file: &fs::File, offset: i64, whence: libc::c_int) -> Result<i64, i32> {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let lseek = libc::lseek64;
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        let lseek = libc::lseek;
+
+        match unsafe { lseek(file.as_raw_fd(), offset, whence) } {
+            -1 => Err(io::Error::last_os_error().raw_os_error().unwrap()),
+            off => Ok(off),
+        }
+    }
+
+    if stat.blocks() == 0 {
+        return Ok(if stat.size() == 0 {
+            // Empty file.
+            None
+        } else {
+            // Fully sparse file.
+            Some(SparseEntries {
+                entries: vec![SparseEntry {
+                    offset: stat.size(),
+                    num_bytes: 0,
+                }],
+                on_disk_size: 0,
+            })
+        });
+    }
+
+    // On most Unices, we need to read `_PC_MIN_HOLE_SIZE` to see if the file
+    // system supports `SEEK_HOLE`.
+    // FreeBSD: https://man.freebsd.org/cgi/man.cgi?query=lseek&sektion=2&manpath=FreeBSD+14.1-STABLE
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    if unsafe { libc::fpathconf(file.as_raw_fd(), libc::_PC_MIN_HOLE_SIZE) } == -1 {
+        return Ok(None);
+    }
+
+    // Linux is the only UNIX-like without support for `_PC_MIN_HOLE_SIZE`, so
+    // instead we try to call `lseek` and see if it fails.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    match lseek(file, 0, libc::SEEK_HOLE) {
+        Ok(_) => (),
+        Err(libc::ENXIO) => {
+            // The file is empty. Treat it as non-sparse.
+            return Ok(None);
+        }
+        Err(_) => return Ok(None),
+    }
+
+    let mut entries = Vec::new();
+    let mut on_disk_size = 0;
+    let mut off_s = 0;
+    loop {
+        //  off_s=0      │     off_s               │ off_s
+        //    ↓          │       ↓                 │   ↓
+        //    | DATA |…  │  ……………| HOLE | DATA |…  │  …|×EOF×
+        //    ↑          │       ↑      ↑          │
+        //   (a)         │  (b) (c)    (d)         │     (e)
+        match lseek(file, off_s, libc::SEEK_DATA) {
+            Ok(0) if off_s == 0 => (), // (a) The file starts with data.
+            Ok(off) if off < off_s => {
+                // (b) Unlikely.
+                return Err(std::io::Error::new(
+                    io::ErrorKind::Other,
+                    "lseek(SEEK_DATA) went backwards",
+                ));
+            }
+            Ok(off) if off == off_s => {
+                // (c) The data at the same offset as the hole.
+                return Err(std::io::Error::new(
+                    io::ErrorKind::Other,
+                    "lseek(SEEK_DATA) did not advance. \
+                     Did the file change while appending?",
+                ));
+            }
+            Ok(off) => off_s = off,    // (d) Jump to the next hole.
+            Err(libc::ENXIO) => break, // (e) Reached the end of the file.
+            Err(errno) => return Err(io::Error::from_raw_os_error(errno)),
+        };
+
+        // off_s=0          │     off_s               │    off_s
+        //   ↓              │       ↓                 │      ↓
+        //   | DATA |×EOF×  │  ……………| DATA | HOLE |…  │  …|×EOF×
+        //          ↑       │       ↑      ↑          │
+        //         (a)      │  (b) (c)    (d)         │     (e)
+        match lseek(file, off_s, libc::SEEK_HOLE) {
+            Ok(off_e) if off_s == 0 && (off_e as u64) == stat.size() => {
+                // (a) The file is not sparse.
+                file.seek(io::SeekFrom::Start(0))?;
+                return Ok(None);
+            }
+            Ok(off_e) if off_e < off_s => {
+                // (b) Unlikely.
+                return Err(std::io::Error::new(
+                    io::ErrorKind::Other,
+                    "lseek(SEEK_HOLE) went backwards",
+                ));
+            }
+            Ok(off_e) if off_e == off_s => {
+                // (c) The hole at the same offset as the data.
+                return Err(std::io::Error::new(
+                    io::ErrorKind::Other,
+                    "lseek(SEEK_HOLE) did not advance. \
+                     Did the file change while appending?",
+                ));
+            }
+            Ok(off_e) => {
+                // (d) Found a hole or reached the end of the file (implicit
+                // zero-length hole).
+                entries.push(SparseEntry {
+                    offset: off_s as u64,
+                    num_bytes: off_e as u64 - off_s as u64,
+                });
+                on_disk_size += off_e as u64 - off_s as u64;
+                off_s = off_e;
+            }
+            Err(libc::ENXIO) => {
+                // (e) off_s was already beyond the end of the file.
+                return Err(std::io::Error::new(
+                    io::ErrorKind::Other,
+                    "lseek(SEEK_HOLE) returned ENXIO. \
+                     Did the file change while appending?",
+                ));
+            }
+            Err(errno) => return Err(io::Error::from_raw_os_error(errno)),
+        };
+    }
+
+    if off_s as u64 > stat.size() {
+        return Err(std::io::Error::new(
+            io::ErrorKind::Other,
+            "lseek(SEEK_DATA) went beyond the end of the file. \
+             Did the file change while appending?",
+        ));
+    }
+
+    // Add a final zero-length entry. It is required if the file ends with a
+    // hole, and redundant otherwise. However, we add it unconditionally to
+    // mimic GNU tar behavior.
+    entries.push(SparseEntry {
+        offset: stat.size(),
+        num_bytes: 0,
+    });
+
+    file.seek(io::SeekFrom::Start(0))?;
+
+    Ok(Some(SparseEntries {
+        entries,
+        on_disk_size,
+    }))
+}
+
 impl<W: Write> Drop for Builder<W> {
     fn drop(&mut self) {
         let _ = self.finish();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Should be multiple of 4KiB on ext4, multiple of 32KiB on FreeBSD/UFS.
+    const SPARSE_BLOCK_SIZE: u64 = 32768;
+
+    #[test]
+    fn test_find_sparse_entries() {
+        let cases: &[(&str, &[SparseEntry])] = &[
+            ("|", &[]),
+            (
+                "|    |    |    |    |",
+                &[SparseEntry {
+                    offset: 4 * SPARSE_BLOCK_SIZE,
+                    num_bytes: 0,
+                }],
+            ),
+            (
+                "|####|####|####|####|",
+                &[
+                    SparseEntry {
+                        offset: 0,
+                        num_bytes: 4 * SPARSE_BLOCK_SIZE,
+                    },
+                    SparseEntry {
+                        offset: 4 * SPARSE_BLOCK_SIZE,
+                        num_bytes: 0,
+                    },
+                ],
+            ),
+            (
+                "|####|####|    |    |",
+                &[
+                    SparseEntry {
+                        offset: 0,
+                        num_bytes: 2 * SPARSE_BLOCK_SIZE,
+                    },
+                    SparseEntry {
+                        offset: 4 * SPARSE_BLOCK_SIZE,
+                        num_bytes: 0,
+                    },
+                ],
+            ),
+            (
+                "|    |    |####|####|",
+                &[
+                    SparseEntry {
+                        offset: 2 * SPARSE_BLOCK_SIZE,
+                        num_bytes: 2 * SPARSE_BLOCK_SIZE,
+                    },
+                    SparseEntry {
+                        offset: 4 * SPARSE_BLOCK_SIZE,
+                        num_bytes: 0,
+                    },
+                ],
+            ),
+            (
+                "|####|    |####|    |",
+                &[
+                    SparseEntry {
+                        offset: 0,
+                        num_bytes: SPARSE_BLOCK_SIZE,
+                    },
+                    SparseEntry {
+                        offset: 2 * SPARSE_BLOCK_SIZE,
+                        num_bytes: SPARSE_BLOCK_SIZE,
+                    },
+                    SparseEntry {
+                        offset: 4 * SPARSE_BLOCK_SIZE,
+                        num_bytes: 0,
+                    },
+                ],
+            ),
+            (
+                "|####|    |    |####|",
+                &[
+                    SparseEntry {
+                        offset: 0,
+                        num_bytes: SPARSE_BLOCK_SIZE,
+                    },
+                    SparseEntry {
+                        offset: 3 * SPARSE_BLOCK_SIZE,
+                        num_bytes: SPARSE_BLOCK_SIZE,
+                    },
+                    SparseEntry {
+                        offset: 4 * SPARSE_BLOCK_SIZE,
+                        num_bytes: 0,
+                    },
+                ],
+            ),
+            (
+                "|    |####|####|    |",
+                &[
+                    SparseEntry {
+                        offset: 1 * SPARSE_BLOCK_SIZE,
+                        num_bytes: 2 * SPARSE_BLOCK_SIZE,
+                    },
+                    SparseEntry {
+                        offset: 4 * SPARSE_BLOCK_SIZE,
+                        num_bytes: 0,
+                    },
+                ],
+            ),
+        ];
+
+        let mut file = tempfile::tempfile().unwrap();
+
+        for &(description, map) in cases {
+            file.set_len(0).unwrap();
+            file.set_len(map.last().map_or(0, |e| e.offset + e.num_bytes))
+                .unwrap();
+
+            for e in map {
+                file.seek(io::SeekFrom::Start(e.offset)).unwrap();
+                for _ in 0..e.num_bytes / SPARSE_BLOCK_SIZE {
+                    file.write_all(&[0xFF; SPARSE_BLOCK_SIZE as usize]).unwrap();
+                }
+            }
+
+            let expected = match map {
+                // Empty file.
+                &[] => None,
+
+                // 100% dense.
+                &[SparseEntry {
+                    offset: 0,
+                    num_bytes: x1,
+                }, SparseEntry {
+                    offset: x2,
+                    num_bytes: 0,
+                }] if x1 == x2 => None,
+
+                // Sparse.
+                map => Some(SparseEntries {
+                    entries: map.to_vec(),
+                    on_disk_size: map.iter().map(|e| e.num_bytes).sum(),
+                }),
+            };
+
+            let stat = file.metadata().unwrap();
+            let reported = find_sparse_entries(&mut file, &stat).unwrap();
+
+            // Loose check: we did not miss any data blocks.
+            if let Err(e) = loose_check_sparse_entries(reported.as_ref(), expected.as_ref()) {
+                panic!(
+                    "Case: {description}\n\
+                     Reported: {reported:?}\n\
+                     Expected: {expected:?}\n\
+                     Error: {e}",
+                );
+            }
+
+            // On Linux, always do a strict check. Skip on FreeBSD, as on UFS
+            // the last block is always dense, even if it's zero-filled.
+            #[cfg(any(target_os = "android", target_os = "linux"))]
+            assert_eq!(reported, expected, "Case: {description}");
+        }
+    }
+
+    fn loose_check_sparse_entries(
+        reported: Option<&SparseEntries>,
+        expected: Option<&SparseEntries>,
+    ) -> Result<(), &'static str> {
+        let reported = match reported {
+            Some(entries) => entries, // Reported as sparse.
+            // It's not an error to report a sparse file as non-sparse.
+            None => return Ok(()),
+        };
+        let expected = match expected {
+            Some(entries) => entries,
+            None => return Err("Expected dense file, but reported as sparse"),
+        };
+
+        // Check that we didn't miss any data blocks. However, reporting some
+        // holes as data is not an error during the loose check.
+        if expected.entries.iter().any(|e| {
+            !reported
+                .entries
+                .iter()
+                .any(|r| e.offset >= r.offset && e.offset + e.num_bytes <= r.offset + r.num_bytes)
+        }) {
+            return Err("Reported is not a superset of expected");
+        }
+
+        if reported.entries.last() != expected.entries.last() {
+            return Err("Last zero-length entry is not as expected");
+        }
+
+        // Check invariants of SparseEntries.
+        let mut prev_end = None;
+        for e in &reported.entries[..reported.entries.len()] {
+            if prev_end.map_or(false, |p| e.offset < p) {
+                return Err("Overlapping or unsorted entries");
+            }
+            prev_end = Some(e.offset + e.num_bytes);
+        }
+
+        if reported.on_disk_size != reported.entries.iter().map(|e| e.num_bytes).sum() {
+            return Err("Incorrect on-disk size");
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR extends `Builder` to support archiving sparse files in the GNU format. This is the format that GNU `tar` produces by default giving the `--sparse` option, assuming `POSIXLY_CORRECT` is not set.

Implementing sparse archives gives two useful properties:
- Archiving a small on-disk file will result in a small archive, even if the file contains large holes. (although this could be solved by piping it into a compressor, e.g. zstd)
- Pack-unpack roundtrip will preserve exact on-disk file sizes. (not solved by piping archive into a compressor)

## Design choices in this PR

1. It uses the gnu/oldgnu format rather than the newer `GNU.sparse` extension to the PAX format.
   Reasons:
   1. The builder coupled with the `GnuHeader` struct already.
   2. Tar-rs already supports reading the old format since https://github.com/alexcrichton/tar-rs/pull/62.
      The PR to support the PAX format https://github.com/alexcrichton/tar-rs/pull/298 remains open.

2. It is enabled by default like BSD tar does, and unlike GNU tar does.

3. It's configured using `Builder::sparse(&mut self, sparse: bool)` method.
   If you think it should be configured via `HeaderMode` instead, please suggest the desired enum layout.

4. It uses `SEEK_HOLE` to detect holes in the file. For comparison, other methods and implementations are listed below.
    | Method                         | System                  | This PR | GNU tar | libarchive<br>BSD tar |
    | ------------------------------ | ----------------------- | ------- | ------- | --------------------- |
    | Raw                            | Any                     | ❌      | ✅      | ❌                    |
    | `SEEK_HOLE`                    | Unix-ish,<br>Linux 3.1+ | ✅      | ✅      | ✅                    |
    | `FIOMAP`                       | Linux 2.6.28+           | ❌      | ❌      | ✅                    |
    | `FSCTL_QUERY_ALLOCATED_RANGES` | Windows                 | ❌      | ❌      | ✅                    |

    The "Raw" method of GNU tar ignores actual holes and works by reading the file in 512-byte blocks and comparing them with zeros.
    I did not include it as I believe it puts this feature into the "compression algorithm" realm, rather than the "preserve filesystem properties" realm.

    I think implementing `FSCTL_QUERY_ALLOCATED_RANGES` method for Windows would be a useful addition, but currently, I don't have much interest in it.

5. ~~Linux, Solaris-like, and FreeBSD-like systems are supported.~~
   ~~After https://github.com/nix-rust/nix/pull/2473 got into the release (v0.30.0 I think), it could be possible to extend it to Hurd and Apple.~~
   <table>
     <tr>
       <th width="120px">System
       <th>Support status
       <th>In this PR
     <tr>
       <td><code>Linux</code>
       <td>Supported.
       <td>Enabled.
     <tr>
       <td><code>freebsd</code>
       <td>Supported with a caveat on UFS: the last block (32KiB) of a file is always dense. Source: my tests on 14.1. Not a huge problem, but needs a special case in unit test.
       <td>Enabled.
     <tr>
       <td><code>hurd</code><br><code>solaris</code><br><code>illumus</code>
       <td>Supported according to docs, didn't tested.
       <td>Disabled due to lack of testing from my side.
     <tr>
       <td><code>dragonfly</code><br><code>netbsd</code><br><code>openbsd</code>
       <td>Not supported at all. Source: <a href="https://github.com/DragonFlyBSD/DragonFlyBSD/blob/v6.5.0/stand/lib/lseek.c#L78-L95">[dragonfly lseek.c]</a>, <a href="https://www.gnu.org/software/gnulib/manual/html_node/lseek.html">[gnulib lseek doc]</a>.
       <td>Disabled.
     <tr>
       <td><code>macos</code>
       <td>Claimed to be supported, but highly problematic. See <a href="https://git.savannah.gnu.org/cgit/gnulib.git/tree/lib/unistd.in.h?id=5b92dd0a45c8d27f13a21076b57095ea5e220870#n43">[gnulib unistd.h.in]</a>, <a href="https://git.savannah.gnu.org/cgit/gnulib.git/tree/lib/lseek.c?id=5b92dd0a45c8d27f13a21076b57095ea5e220870#n58">[gnulib lseek.c]</a>, <a href="https://www.gnu.org/software/gnulib/manual/html_node/lseek.html">[gnulib lseek doc]</a>. Also, I did catch a weird behavior on macOS github runners: files loose their sparseness right after the moment you close them.
       <td>Disabled.
   </table>

6. ~~A new dependency `nix` is pulled for convenience.~~
   ~~As a consequence, the MSRV is raised to 1.69.~~
   ~~Although it's possible to rewrite it with unsafe `libc` calls if that's preferred.~~

7. During archive creation, it allocates 16 bytes of memory per hole. (see `struct SparseEntries`)
   In the worst pathological case, it will allocate 2 MiB per GiB of a file in a "zebra" pattern. (4096 bytes of data followed by a 4096-byte hole)
   If it's a concern, I think, it's possible to implement it in an allocation-free way for `Builder<SW> where W: Seek + Write`.

8. Two tests involving sparse files are added.
   Tests are run unconditionally, but strict checks are only done in the following cases:
   - `tests/all.rs` `writing_sparse`: strict only on Linux. Not strict on FreeBSD due to the UFS caveat mentioned above.
   - `src/builder.rs` `test_find_sparse_entries`: strict on Linux and FreeBSD.

   Potentially, these strict checks might fail when run on a filesystem that doesn't support holes.