### PR TITLE
Very basic Pax header writer

### DIFF
--- a/src/pax.rs
+++ b/src/pax.rs
@@ -154,9 +154,9 @@ impl<T: Write> crate::Builder<T> {
     /// Takes in an iterator over the list of headers to add to convert it into a header set formatted.
     ///
     /// Returns io::Error if an error occurs, else it returns ()
-    pub fn append_pax_extensions<'a>(
+    pub fn append_pax_extensions<'key, 'value>(
         &mut self,
-        headers: impl IntoIterator<Item = (String, String)>,
+        headers: impl IntoIterator<Item = (&'key str, &'value [u8])>,
     ) -> Result<(), io::Error> {
         // Store the headers formatted before write
         let mut data: Vec<u8> = Vec::new();
@@ -172,7 +172,9 @@ impl<T: Write> crate::Builder<T> {
                 max_len *= 10;
             }
             let len = rest_len + len_len;
-            write!(&mut data, "{} {}={}\n", len, key, value)?;
+            write!(&mut data, "{} {}=", len, key)?;
+            data.extend_from_slice(value);
+            data.push(b'\n');
         }
 
         // Ignore the header append if it's empty.

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -6,12 +6,12 @@ extern crate xattr;
 
 use std::fs::{self, File};
 use std::io::prelude::*;
-use std::io::{self, Cursor};
+use std::io::{self, BufWriter, Cursor};
 use std::iter::repeat;
 use std::path::{Path, PathBuf};
 
 use filetime::FileTime;
-use tar::{Archive, Builder, Entries, EntryType, Header, HeaderMode};
+use tar::{Archive, Builder, Entries, Entry, EntryType, Header, HeaderMode};
 use tempfile::{Builder as TempBuilder, TempDir};
 
 macro_rules! t {
@@ -923,6 +923,38 @@ fn pax_simple() {
     assert_eq!(second.value(), Ok("1453251915.24892486"));
     assert_eq!(third.key(), Ok("ctime"));
     assert_eq!(third.value(), Ok("1453146164.953123768"));
+}
+
+#[test]
+fn pax_simple_write() {
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
+    let pax_path = td.path().join("pax.tar");
+    let file: File = t!(File::create(&pax_path));
+    let mut ar: Builder<BufWriter<File>> = Builder::new(BufWriter::new(file));
+
+    let mut pax_builder: Vec<(String, String)> = Vec::new();
+    let key: String = "arbitrary_pax_key".to_string();
+    let value: String = "arbitrary_pax_value".to_string();
+    pax_builder.push((key, value));
+
+    t!(ar.append_pax_extensions(pax_builder.into_iter()));
+    t!(ar.append_file("test2", &mut t!(File::open(&pax_path))));
+    t!(ar.finish());
+    drop(ar);
+
+    let mut archive_opened = Archive::new(t!(File::open(pax_path)));
+    let mut entries = t!(archive_opened.entries());
+    let mut f: Entry<File> = t!(entries.next().unwrap());
+    let pax_headers = t!(f.pax_extensions());
+
+    assert!(pax_headers.is_some(), "pax_headers is None");
+    let mut pax_headers = pax_headers.unwrap();
+    let pax_arbitrary = t!(pax_headers.next().unwrap());
+
+    assert_eq!(pax_arbitrary.key(), Ok("arbitrary_pax_key"));
+    assert_eq!(pax_arbitrary.value(), Ok("arbitrary_pax_value"));
+
+    assert!(entries.next().is_none());
 }
 
 #[test]

--- a/tests/entry.rs
+++ b/tests/entry.rs
@@ -1,7 +1,8 @@
 extern crate tar;
 extern crate tempfile;
 
-use std::fs::{create_dir, File};
+use std::fs::create_dir;
+use std::fs::File;
 use std::io::Read;
 
 use tempfile::Builder;


### PR DESCRIPTION
Basic implem of PaxBuilder that can add the header with the data provided, implem on tar::builder

Today the lib is able to read the pax headers, even if they have arbitrary values but can't write some headers back. This update lets you do that very simply.

Usage:
```rust
let mut pax_builder: PaxBuilder = PaxBuilder::new();

let value: String = "a_value".to_string();
let key: String = "a_key".to_string();

pax_builder.add(&key, &value);

let res_write_pax: Result<(), io::Error> = my_open_tar_archive.append_pax_extensions(&pax_builder);
```