### PR TITLE
Fix long names (GNUTYPE_LONGNAME)

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -193,7 +193,8 @@ impl Header {
 
     fn is_ustar(&self) -> bool {
         let ustar = unsafe { cast::<_, UstarHeader>(self) };
-        ustar.magic[..] == b"ustar\0"[..] && ustar.version[..] == b"00"[..]
+        ustar.magic[..] == b"ustar\0"[..]
+             && (ustar.version[..] == b"00"[..] || ustar.version[..] == b"\0\0"[..])
     }
 
     fn is_gnu(&self) -> bool {

--- a/src/header.rs
+++ b/src/header.rs
@@ -194,7 +194,7 @@ impl Header {
     fn is_ustar(&self) -> bool {
         let ustar = unsafe { cast::<_, UstarHeader>(self) };
         ustar.magic[..] == b"ustar\0"[..]
-             && (ustar.version[..] == b"00"[..] || ustar.version[..] == b"\0\0"[..])
+            && (ustar.version[..] == b"00"[..] || ustar.version[..] == b"\0\0"[..])
     }
 
     fn is_gnu(&self) -> bool {


### PR DESCRIPTION
The patch suggested by @RazerM in #369 is fixing my problem of a truncated file name during extraction. In my case the long file names ended up in the root of the extraction directory rather than the sub-directory they have in the archive.

>  I'm also not sure what the best way forward is for handling this is. I can't find anything about why these bytes might be different than expected, if not just a mixup of \0 and 0.

Is what @RazerM said last week. I'll be honest here: I don't have a clue at all. I'm just creating a PR for the solution that is solving my problem.