### PR TITLE
fix for archiving long paths that have path components starting with ".." crossing the 100-character mark

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -768,7 +768,7 @@ fn prepare_header_path(dst: &mut dyn Write, header: &mut Header, path: &Path) ->
             Ok(s) => s,
             Err(e) => str::from_utf8(&data[..e.valid_up_to()]).unwrap(),
         };
-        header.set_path(truncated)?;
+        header.set_truncated_path_for_gnu_header(&truncated)?;
     }
     Ok(())
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1605,12 +1605,16 @@ fn copy_path_into_inner(
     }
 }
 
+/// Copies `path` into the `slot` provided
+///
+/// Returns an error if:
+///
+/// * the path is too long to fit
+/// * a nul byte was found
+/// * an invalid path component is encountered (e.g. a root path or parent dir)
+/// * the path itself is empty
 fn copy_path_into(slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
     copy_path_into_inner(slot, path, is_link_name, false)
-}
-
-fn copy_path_into_gnu_long(slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
-    copy_path_into_inner(slot, path, is_link_name, true)
 }
 
 /// Copies `path` into the `slot` provided
@@ -1621,6 +1625,11 @@ fn copy_path_into_gnu_long(slot: &mut [u8], path: &Path, is_link_name: bool) -> 
 /// * a nul byte was found
 /// * an invalid path component is encountered (e.g. a root path or parent dir)
 /// * the path itself is empty
+///
+/// This is less restrictive version meant to be used for truncated GNU paths.
+fn copy_path_into_gnu_long(slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
+    copy_path_into_inner(slot, path, is_link_name, true)
+}
 
 #[cfg(target_arch = "wasm32")]
 fn ends_with_slash(p: &Path) -> bool {

--- a/src/header.rs
+++ b/src/header.rs
@@ -386,7 +386,10 @@ impl Header {
     // Sets the truncated path for GNU header
     //
     // Same as set_path but skips some validations.
-    pub(crate) fn set_truncated_path_for_gnu_header<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
+    pub(crate) fn set_truncated_path_for_gnu_header<P: AsRef<Path>>(
+        &mut self,
+        p: P,
+    ) -> io::Result<()> {
         self._set_path(p.as_ref(), true)
     }
 
@@ -394,7 +397,13 @@ impl Header {
         if let Some(ustar) = self.as_ustar_mut() {
             return ustar.set_path(path);
         }
-        copy_path_into(&mut self.as_old_mut().name, path, false, is_truncated_gnu_long_path).map_err(|err| {
+        copy_path_into(
+            &mut self.as_old_mut().name,
+            path,
+            false,
+            is_truncated_gnu_long_path,
+        )
+        .map_err(|err| {
             io::Error::new(
                 err.kind(),
                 format!("{} when setting path for {}", err, self.path_lossy()),
@@ -1547,7 +1556,12 @@ fn copy_into(slot: &mut [u8], bytes: &[u8]) -> io::Result<()> {
 /// * a nul byte was found
 /// * an invalid path component is encountered (e.g. a root path or parent dir)
 /// * the path itself is empty
-fn copy_path_into(mut slot: &mut [u8], path: &Path, is_link_name: bool, is_truncated_gnu_long_path: bool) -> io::Result<()> {
+fn copy_path_into(
+    mut slot: &mut [u8],
+    path: &Path,
+    is_link_name: bool,
+    is_truncated_gnu_long_path: bool,
+) -> io::Result<()> {
     let mut emitted = false;
     let mut needs_slash = false;
     let mut iter = path.components().peekable();
@@ -1562,8 +1576,7 @@ fn copy_path_into(mut slot: &mut [u8], path: &Path, is_link_name: bool, is_trunc
                     // If it's last component of a gnu long path we know that there might be more
                     // to the component than .. (the rest is stored elsewhere)
                     {}
-                }
-                else {
+                } else {
                     return Err(other("paths in archives must not have `..`"));
                 }
             }

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -215,7 +215,7 @@ fn large_filename_with_dot_dot_at_100_byte_mark() {
     header.set_mode(0o644);
     header.set_size(4);
 
-    let mut long_name_with_dot_dot  = "tdir/".repeat(19);
+    let mut long_name_with_dot_dot = "tdir/".repeat(19);
     long_name_with_dot_dot.push_str("tt/..file");
 
     t!(ar.append_data(&mut header, &long_name_with_dot_dot, &b"test"[..]));
@@ -232,8 +232,6 @@ fn large_filename_with_dot_dot_at_100_byte_mark() {
     assert_eq!(s, "test");
     assert!(entries.next().is_none());
 }
-
-
 
 fn reading_entries_common<R: Read>(mut entries: Entries<R>) {
     let mut a = t!(entries.next().unwrap());

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -211,14 +211,13 @@ fn large_filename_with_dot_dot_at_100_byte_mark() {
     let mut ar = Builder::new(Vec::new());
 
     let mut header = Header::new_gnu();
-    header.set_cksum();
     header.set_mode(0o644);
     header.set_size(4);
 
     let mut long_name_with_dot_dot = "tdir/".repeat(19);
     long_name_with_dot_dot.push_str("tt/..file");
 
-    t!(ar.append_data(&mut header, &long_name_with_dot_dot, &b"test"[..]));
+    t!(ar.append_data(&mut header, &long_name_with_dot_dot, b"test".as_slice()));
 
     let rd = Cursor::new(t!(ar.into_inner()));
     let mut ar = Archive::new(rd);

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -218,22 +218,19 @@ fn large_filename_with_dot_dot_at_100_byte_mark() {
     let mut long_name_with_dot_dot  = "tdir/".repeat(19);
     long_name_with_dot_dot.push_str("tt/..file");
 
-    // The following fails with:
-    // "returned paths in archives must not have `..` when setting path for tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tt"
-    assert!(ar.append_data(&mut header, &long_name_with_dot_dot, &b"test"[..]).is_err());
+    t!(ar.append_data(&mut header, &long_name_with_dot_dot, &b"test"[..]));
 
-    // Once the tests passes the following should be uncommented.
-    // let rd = Cursor::new(t!(ar.into_inner()));
-    // let mut ar = Archive::new(rd);
-    // let mut entries = t!(ar.entries());
+    let rd = Cursor::new(t!(ar.into_inner()));
+    let mut ar = Archive::new(rd);
+    let mut entries = t!(ar.entries());
 
-    // let mut f = entries.next().unwrap().unwrap();
-    // assert_eq!(&*f.path_bytes(), long_name_with_dot_dot.as_bytes());
-    // assert_eq!(f.header().size().unwrap(), 4);
-    // let mut s = String::new();
-    // t!(f.read_to_string(&mut s));
-    // assert_eq!(s, "test");
-    // assert!(entries.next().is_none());
+    let mut f = entries.next().unwrap().unwrap();
+    assert_eq!(&*f.path_bytes(), long_name_with_dot_dot.as_bytes());
+    assert_eq!(f.header().size().unwrap(), 4);
+    let mut s = String::new();
+    t!(f.read_to_string(&mut s));
+    assert_eq!(s, "test");
+    assert!(entries.next().is_none());
 }
 
 

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -203,6 +203,41 @@ fn large_filename() {
     assert!(entries.next().is_none());
 }
 
+// This test checks very particular scenario where a path component starting
+// with ".." of a long path gets split at 100-byte mark so that ".." part goes
+// into header and gets interpreted as parent dir (and rejected) .
+#[test]
+fn large_filename_with_dot_dot_at_100_byte_mark() {
+    let mut ar = Builder::new(Vec::new());
+
+    let mut header = Header::new_gnu();
+    header.set_cksum();
+    header.set_mode(0o644);
+    header.set_size(4);
+
+    let mut long_name_with_dot_dot  = "tdir/".repeat(19);
+    long_name_with_dot_dot.push_str("tt/..file");
+
+    // The following fails with:
+    // "returned paths in archives must not have `..` when setting path for tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tdir/tt"
+    assert!(ar.append_data(&mut header, &long_name_with_dot_dot, &b"test"[..]).is_err());
+
+    // Once the tests passes the following should be uncommented.
+    // let rd = Cursor::new(t!(ar.into_inner()));
+    // let mut ar = Archive::new(rd);
+    // let mut entries = t!(ar.entries());
+
+    // let mut f = entries.next().unwrap().unwrap();
+    // assert_eq!(&*f.path_bytes(), long_name_with_dot_dot.as_bytes());
+    // assert_eq!(f.header().size().unwrap(), 4);
+    // let mut s = String::new();
+    // t!(f.read_to_string(&mut s));
+    // assert_eq!(s, "test");
+    // assert!(entries.next().is_none());
+}
+
+
+
 fn reading_entries_common<R: Read>(mut entries: Entries<R>) {
     let mut a = t!(entries.next().unwrap());
     assert_eq!(&*a.header().path_bytes(), b"a");


### PR DESCRIPTION
The gnu tar supports arbirary path length by putting path truncated to standard 100 chars into the header and the rest is appended to contents. `tar-rs` validates that no path components should be exactly  ".." but in this case when a component starting with ".." (for example file named "..some_file") gets truncated after 2 characters we hit this validation and can't tar such file.

I have verified that gnu `tar` command can handle such paths and actually puts truncated `..` in the header. This pull request makes `tar-rs` behave the same.

See tests for repro of the issue.

(I think the code for handling this special case is quite ugly - I'd appreciate suggestions for making it better)