### PR TITLE
Use zerocopy instead of raw transmute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ contents are never required to be entirely resident in memory all at once.
 
 [dependencies]
 filetime = "0.2.8"
+zerocopy = { version = "0.8.12", features = [ "derive" ] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -953,6 +953,7 @@ fn find_sparse_entries_seek(
     use std::os::unix::fs::MetadataExt as _;
     use std::os::unix::io::AsRawFd as _;
 
+    #[allow(unsafe_code)]
     fn lseek(file: &fs::File, offset: i64, whence: libc::c_int) -> Result<i64, i32> {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         let lseek = libc::lseek64;

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -730,6 +730,7 @@ impl<'a> EntryFields<'a> {
         }
 
         #[cfg(unix)]
+        #[allow(unsafe_code)]
         fn _set_ownerships(
             dst: &Path,
             f: &Option<&mut std::fs::File>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 
 #![doc(html_root_url = "https://docs.rs/tar/0.4")]
 #![deny(missing_docs)]
+// The only exceptions right now are calls to libc; TODO use rustix
+#![deny(unsafe_code)]
 #![cfg_attr(test, deny(warnings))]
 
 use std::io::{Error, ErrorKind};


### PR DESCRIPTION
This is a very old crate, and when I first started learning Rust, I thought a tar parser was exactly the kind of thing that should showcase Rust's claimed safety and speed.

I remember being surprised at the usage of `unsafe` here...thinking it undermined some of the Rust claims.

I didn't think about it too much more though, but I now understand that it wasn't exactly a language limitation (if we wanted to we could just have `Header` and functions which reinterpret fields manually) but nowadays the zerocopy crate has emerged as the go-to default for ergonomically deriving and proving at compile time the safety of these types of transmutations.

Let's start using it.

(Also use `#[derive(Default)]` instead of the unsafe `mem::zeroed()`
 for `GnuExtSparseHeader)

Now I also went ahead and added a `#[deny(unsafe_code)]` - there's only a few calls to libc functions which could be replaced with rustix or nix...but that's a different topic.

Adding a new dependency
-----------------------

I am aware that this crate is widely used, including by e.g. `cargo`. I went ahead and proactively checked and it turns out that zerocopy is already a dependency of `ahash`, which is already a cargo dependency.