### PR TITLE
Make it compile with wasm32-unknown-emscripten

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -603,7 +603,7 @@ impl<'a> EntryFields<'a> {
                 ::std::os::windows::fs::symlink_file(src, dst)
             }
 
-            #[cfg(unix)]
+            #[cfg(all(unix, not(target_arch = "wasm32")))]
             fn symlink(src: &Path, dst: &Path) -> io::Result<()> {
                 ::std::os::unix::fs::symlink(src, dst)
             }
@@ -729,7 +729,7 @@ impl<'a> EntryFields<'a> {
             })
         }
 
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_arch = "wasm32")))]
         fn _set_ownerships(
             dst: &Path,
             f: &Option<&mut std::fs::File>,
@@ -800,7 +800,7 @@ impl<'a> EntryFields<'a> {
             })
         }
 
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_arch = "wasm32")))]
         fn _set_perms(
             dst: &Path,
             f: Option<&mut std::fs::File>,
@@ -856,7 +856,7 @@ impl<'a> EntryFields<'a> {
             Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
         }
 
-        #[cfg(all(unix, feature = "xattr"))]
+        #[cfg(all(unix, not(target_arch = "wasm32"), feature = "xattr"))]
         fn set_xattrs(me: &mut EntryFields, dst: &Path) -> io::Result<()> {
             use std::ffi::OsStr;
             use std::os::unix::prelude::*;

--- a/src/header.rs
+++ b/src/header.rs
@@ -773,7 +773,7 @@ impl Header {
         unimplemented!();
     }
 
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_arch = "wasm32")))]
     fn fill_platform_from(&mut self, meta: &fs::Metadata, mode: HeaderMode) {
         match mode {
             HeaderMode::Complete => {
@@ -1650,7 +1650,7 @@ fn ends_with_slash(p: &Path) -> bool {
     last == Some(b'/' as u16) || last == Some(b'\\' as u16)
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 fn ends_with_slash(p: &Path) -> bool {
     p.as_os_str().as_bytes().ends_with(&[b'/'])
 }
@@ -1677,7 +1677,7 @@ pub fn path2bytes(p: &Path) -> io::Result<Cow<[u8]>> {
         })
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 /// On unix this will never fail
 pub fn path2bytes(p: &Path) -> io::Result<Cow<[u8]>> {
     Ok(p.as_os_str().as_bytes()).map(Cow::Borrowed)
@@ -1706,7 +1706,7 @@ pub fn bytes2path(bytes: Cow<[u8]>) -> io::Result<Cow<Path>> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 /// On unix this operation can never fail.
 pub fn bytes2path(bytes: Cow<[u8]>) -> io::Result<Cow<Path>> {
     use std::ffi::{OsStr, OsString};


### PR DESCRIPTION
Make it so that emscripten works. Now you can do:

```
rustup target add wasm32-unknown-emscripten
cargo build --target=wasm32-unknown-emscripten
```

And it works. Unlike the other WASM target, emscripten configures itself to work with both `unix` and `wasm`, so we have to avoid the unix branch.

A more recent variant of the patch in #301. For that PR, it was suggested that cfg_if would be a reasonable alternative. I'm happy to go that route if you want, but found that it makes things more complicated (to my eye). But maintainers choice.