### PR TITLE
Add WASM CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,14 @@ jobs:
       run: sudo -E $(which cargo) test
       if: ${{ matrix.os == 'ubuntu-latest' }}
 
+  wasm:
+    name: Wasm
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - run: rustup target add wasm32-unknown-emscripten
+    - run: cargo build --target=wasm32-unknown-emscripten
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/src/header.rs
+++ b/src/header.rs
@@ -1721,11 +1721,11 @@ pub fn bytes2path(bytes: Cow<[u8]>) -> io::Result<Cow<Path>> {
 pub fn bytes2path(bytes: Cow<[u8]>) -> io::Result<Cow<Path>> {
     Ok(match bytes {
         Cow::Borrowed(bytes) => {
-            Cow::Borrowed({ Path::new(str::from_utf8(bytes).map_err(invalid_utf8)?) })
+            Cow::Borrowed(Path::new(str::from_utf8(bytes).map_err(invalid_utf8)?))
         }
-        Cow::Owned(bytes) => {
-            Cow::Owned({ PathBuf::from(String::from_utf8(bytes).map_err(invalid_utf8)?) })
-        }
+        Cow::Owned(bytes) => Cow::Owned(PathBuf::from(
+            String::from_utf8(bytes).map_err(invalid_utf8)?,
+        )),
     })
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,4 +1,4 @@
-#[cfg(unix)]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 use std::os::unix::prelude::*;
 #[cfg(windows)]
 use std::os::windows::prelude::*;
@@ -21,7 +21,7 @@ use crate::EntryType;
 ///
 /// This value, chosen after careful deliberation, corresponds to _Jul 23, 2006_,
 /// which is the date of the first commit for what would become Rust.
-#[cfg(any(unix, windows))]
+#[cfg(all(any(unix, windows), not(target_arch = "wasm32")))]
 const DETERMINISTIC_TIMESTAMP: u64 = 1153704088;
 
 pub(crate) const BLOCK_SIZE: u64 = 512;


### PR DESCRIPTION
This fixes the warnings that appear with WASM, then adds CI for it. I initially tried putting it in the matrix, but it is just too different (it's a target, not a toolchain) so doing it as an entirely separate test worked better.