### PR TITLE
Request: Function to add files from in-memory data

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -184,6 +184,22 @@ impl<W: Write> Builder<W> {
         self.append(&header, data)
     }
 
+    /// Add a file entry to the archive.
+    ///
+    /// This function will create a header for a file of correct size, mode, and checksum.
+    pub fn append_file_data<P: AsRef<Path>>(
+        &mut self,
+        path: P,
+        mode: u32,
+        data: &[u8],
+    ) -> io::Result<()> {
+        let mut header = Header::new_gnu();
+        header.set_size(data.len() as u64);
+        header.set_mode(mode);
+        header.set_cksum();
+        self.append_data(&mut header, path, data)
+    }
+
     /// Adds a new entry to this archive and returns an [`EntryWriter`] for
     /// adding its contents.
     ///


### PR DESCRIPTION
> [!NOTE]
> I am aware that this "PR" is not up to your standard. I just create a PR instead of an issue to better illustrate my feature request. Please consider this a feature request instead of a proper PR. If you have requests for change, feel free to edit this PR directly.


It's quite inconvenient that `tar-rs` doesn't provide a convenient function to quickly add in-memory data to a tar archive as files.

## Why not `Builder::append_data`?

Constructing `Header` is too verbose and error-prone. As a consumer of this package, I had to various trials and errors to create a correct `Header` that would produce a valid tar file that can be parsed by other programs in my Linux machine.

## Why not `Builder::append_file`?

This function requires reading a file from the filesystem, but my use case was data stored as `&[u8]` in-memory. To write this data to the filesystem then read it would be suboptimal.
