### PR TITLE
header: update doc for Header.path

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -351,6 +351,8 @@ impl Header {
     ///
     /// Note that this function will convert any `\` characters to directory
     /// separators.
+    /// It is recommended to use `Entry.path()` instead of inspecting the `header`
+    /// directly to ensure that various archive formats are handled correctly.
     pub fn path(&self) -> io::Result<Cow<Path>> {
         bytes2path(self.path_bytes())
     }


### PR DESCRIPTION
Add further documentation for #292; I missed the existence of `Entry.path()` and spent a while being confused about why I only had 100 characters of path.