### PR TITLE
entry: Add set_mode method

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -352,6 +352,7 @@ impl<'a> EntriesFields<'a> {
             long_linkname: None,
             pax_extensions: None,
             mask: self.archive.inner.mask,
+            mode: None,
             unpack_xattrs: self.archive.inner.unpack_xattrs,
             preserve_permissions: self.archive.inner.preserve_permissions,
             preserve_mtime: self.archive.inner.preserve_mtime,


### PR DESCRIPTION
`set_mask` is useful but sometimes setting the exact mode is more precise.

Here: `set_mode` accepts a `u32` for setting an explicit mode. By default the field is `None` so if not specified, the mode is unchanged, at least before the mask.

Q: I don't know windows, or really any non-unix, standards for permissions so I wasn't sure if this should be unix-only. What do you think?