### PR TITLE
OSS-Fuzz: Use derive via Arbitrary feature flag

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,9 +8,8 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = "1.3.2"
+arbitrary = { version = "1.3.2", features = ["derive"] }
 cap-std = "3.4.0"
-derive_arbitrary = "1.3.2"
 libfuzzer-sys = "0.4"
 tempfile = "3.3"
 

--- a/fuzz/fuzz_targets/archive.rs
+++ b/fuzz/fuzz_targets/archive.rs
@@ -17,7 +17,6 @@
 use arbitrary::{Arbitrary, Unstructured};
 use cap_std::fs::Dir;
 use cap_std::ambient_authority;
-use derive_arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 use std::io::{Cursor, Write};
 use tar::{Archive, Builder, EntryType, Header};


### PR DESCRIPTION
Before this change, the fuzzing target uses the arbitrary crate without its derive feature flag, and instead imports both the Arbitrary type from the arbitrary crate and the Arbitrary derive macro from the derive_arbitrary crate.

When building in an environment that enables the `derive` feature of the arbitrary crate, this causes an error due to the ambiguity produced by having two separate imports of a derive macro called Arbitrary.

This change drops the separate derive_arbitrary crate and instead enables the `derive` feature of the arbitrary crate, which resolves the ambiguity.