### PR TITLE
fix: expose `DETERMINISTIC_TIMESTAMP`

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -21,7 +21,7 @@ use crate::EntryType;
 /// This value, chosen after careful deliberation, corresponds to _Jul 23, 2006_,
 /// which is the date of the first commit for what would become Rust.
 #[cfg(all(any(unix, windows), not(target_arch = "wasm32")))]
-const DETERMINISTIC_TIMESTAMP: u64 = 1153704088;
+pub const DETERMINISTIC_TIMESTAMP: u64 = 1153704088;
 
 pub(crate) const BLOCK_SIZE: u64 = 512;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub use crate::builder::{Builder, EntryWriter};
 pub use crate::entry::{Entry, Unpacked};
 pub use crate::entry_type::EntryType;
 pub use crate::header::GnuExtSparseHeader;
+#[cfg(all(any(unix, windows), not(target_arch = "wasm32")))]
+pub use crate::header::DETERMINISTIC_TIMESTAMP;
 pub use crate::header::{GnuHeader, GnuSparseHeader, Header, HeaderMode, OldHeader, UstarHeader};
 pub use crate::pax::{PaxExtension, PaxExtensions};
 


### PR DESCRIPTION
This exposes `DETERMINISTIC_TIMESTAMP` so for people creating tar entries on the file (i.e., not having file on disk so have no access to `fs::Metadata` to call [`Header::set_metadata`](https://docs.rs/tar/0.4.44/tar/struct.Header.html#method.set_metadata).

This is wanted by <https://github.com/rust-lang/cargo/issues/16237>, though in Cargo we can probably hardcode that timestamp.