### PR TITLE
Fix docs typo in header.rs

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -123,7 +123,7 @@ pub struct GnuHeader {
     pub pad: [u8; 17],
 }
 
-/// Description of the header of a spare entry.
+/// Description of the header of a sparse entry.
 ///
 /// Specifies the offset/number of bytes of a chunk of data in octal.
 #[repr(C)]


### PR DESCRIPTION
I noticed this at https://docs.rs/tar/latest/tar/ :slightly_smiling_face: 