### PR TITLE
Add `Entry::set_path_bytes`

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -88,6 +88,14 @@ impl<'a, R: Read> Entry<'a, R> {
         self.fields.path_bytes()
     }
 
+    /// Sets the raw bytes listed for this entry.
+    ///
+    /// Subsequent calls to [`path_bytes`][Self::path_bytes] will return the
+    /// provided value.
+    pub fn set_path_bytes(&mut self, path_bytes: Vec<u8>) {
+        self.fields.long_pathname = Some(path_bytes);
+    }
+
     /// Returns the link name for this entry, if any is found.
     ///
     /// This method may fail if the pathname is not valid Unicode and this is


### PR DESCRIPTION
This allows mapping paths when unpacking an archive.

## Context

I’m working on [a backup system](https://github.com/prose-im/prose-pod-server/tree/backups/api/crates/backup), which uses tar as the archive format. Backups must be immutable, but still be restorable after schema (file hierarchy) changes. For this I implemented migrations, which are basically just path mappings.

At first I was unpacking in a temporary directory, renaming directories, then moving them to their final destination. It was simple and effective, but it broke when I realized I had to unpack in mounted paths (and `fs::rename` doesn’t work across devices).

I thought about using symlinks, but the I/O overhead is massive if paths have to be resolved for every single archive entry. The other obvious solution was to map paths while unpacking the archives. Unfortunately, the crate doesn’t provide any API for that and I’d have to re-implement a lot of logic to get it working (security footgun).

Here is a tiny one-liner which exposes just what one needs to unlock this use case. Ideally I’d like a way to not have to re-implement `tar::Archive::unpack`, but it’s acceptable (not too much logic). I might submit another PR if I find an API that’d qualify as a patch without affecting performance (and without duplicating code).

---

By the way thank you for the library, it’s great!