### PR TITLE
Add `Archive::unpack_mapped`

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -120,7 +120,18 @@ impl<R: Read> Archive<R> {
     /// ```
     pub fn unpack<P: AsRef<Path>>(&mut self, dst: P) -> io::Result<()> {
         let me: &mut Archive<dyn Read> = self;
-        me._unpack(dst.as_ref())
+        me._unpack(dst.as_ref(), |_| {})
+    }
+
+    /// Same as [`unpack`][Self::unpack], but allows mapping entries during the
+    /// iteration.
+    pub fn unpack_mapped<P: AsRef<Path>>(
+        &mut self,
+        dst: P,
+        map_entry: impl Fn(&mut Entry<io::Empty>),
+    ) -> io::Result<()> {
+        let me: &mut Archive<dyn Read> = self;
+        me._unpack(dst.as_ref(), map_entry)
     }
 
     /// Set the mask of the permission bits when unpacking this entry.
@@ -226,7 +237,7 @@ impl Archive<dyn Read + '_> {
         })
     }
 
-    fn _unpack(&mut self, dst: &Path) -> io::Result<()> {
+    fn _unpack(&mut self, dst: &Path, map_entry: impl Fn(&mut Entry<io::Empty>)) -> io::Result<()> {
         if dst.symlink_metadata().is_err() {
             fs::create_dir_all(dst)
                 .map_err(|e| TarError::new(format!("failed to create `{}`", dst.display()), e))?;
@@ -245,6 +256,11 @@ impl Archive<dyn Read + '_> {
         let mut directories = Vec::new();
         for entry in self._entries(None)? {
             let mut file = entry.map_err(|e| TarError::new("failed to iterate over archive", e))?;
+
+            // Map the entry if needed (e.g. to map its path).
+            // In most cases, this will be a no-op.
+            map_entry(&mut file);
+
             if file.header().entry_type() == crate::EntryType::Directory {
                 directories.push(file);
             } else {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -88,6 +88,14 @@ impl<'a, R: Read> Entry<'a, R> {
         self.fields.path_bytes()
     }
 
+    /// Sets the raw bytes listed for this entry.
+    ///
+    /// Subsequent calls to [`path_bytes`][Self::path_bytes] will return the
+    /// provided value.
+    pub fn set_path_bytes(&mut self, path_bytes: Vec<u8>) {
+        self.fields.long_pathname = Some(path_bytes);
+    }
+
     /// Returns the link name for this entry, if any is found.
     ///
     /// This method may fail if the pathname is not valid Unicode and this is


### PR DESCRIPTION
(Follow-up to #448, merge first.)

This allows mapping paths while extracting, if #448 gets merged. See this other PR for rationale.

We can discuss implementation, as I’m aware I introduced some genericity which might affect performance / binary size / compile time. There are no benchmarks so I couldn’t know if my changes had an impact. It _should_ not since most people will never use `unpack_mapped` and `_unpack` will get monomorphized to the exact same function as before, with the compiler likely optimizing away the newly added line as it’s a no-op. And in the rare case where one needs `unpack_mapped`, they’d likely have a single call site so `unpack_mapped` wouldn’t bloat the binary. But that’s just my opinion, I’d get it if you want to use dynamic dispatch instead.

Oh and also feel free to change the method name, I had no inspiration 🙆‍♂️