### PR TITLE
ci: Add crates.io trusted publishing workflow

### DIFF
--- a/.github/workflows/cratesio-release.yml
+++ b/.github/workflows/cratesio-release.yml
@@ -1,0 +1,17 @@
+# See https://crates.io/docs/trusted-publishing
+name: Publish to crates.io
+on:
+  push:
+    tags: ['v*', '[0-9]*']  # Triggers on version tags (e.g. v0.4.46 or 0.4.46)
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write     # Required for OIDC token exchange
+    steps:
+    - uses: actions/checkout@v6
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Triggers on version tags (both v* and bare 0.x.y styles used historically). Requires configuring trusted publishing on crates.io for this repo.

Assisted-by: OpenCode (Claude Sonnet 4.6)