### PR TITLE
ci: Enable merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [master, main]
   pull_request:
     branches: [master, main]
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always
@@ -126,13 +127,14 @@ jobs:
     if: always()
     needs: [test, wasm, rustfmt, semver-checks, revdep, publish_docs]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
     steps:
-      - run: exit 1
-        if: >-
-          needs.test.result != 'success' ||
-          needs.wasm.result != 'success' ||
-          needs.rustfmt.result != 'success' ||
-          needs.semver-checks.result != 'success' ||
-          needs.revdep.result != 'success' ||
-          needs.publish_docs.result != 'success'
+      - name: Check all jobs
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          FAILED=$(echo "$NEEDS" | jq -r 'to_entries[] | select(.value.result | IN("success","skipped") | not) | .key')
+          if [ -n "$FAILED" ]; then
+            echo "The following jobs did not succeed: $FAILED"
+            exit 1
+          fi
+          echo "All jobs succeeded or were skipped."


### PR DESCRIPTION
Add the `merge_group` event trigger so CI runs when a pull request enters the GitHub merge queue. Also add a `required-checks` sentinel job that gates on all other jobs — this is the single status check name to configure in repository branch protection settings.

xref: https://github.com/bootc-dev/infra/issues/143